### PR TITLE
removed detailed tgz files from file list

### DIFF
--- a/website_frontend/src/pages/SystemPage.jsx
+++ b/website_frontend/src/pages/SystemPage.jsx
@@ -1203,7 +1203,7 @@ function SystemPage() {
                 )
               : name;
             if (!nameLux.isValid && !nameLocal.match(/^run_[a-zA-Z0-9]{6,7}.*\.log$/) && !nameLocal.match(/^output\.log$/)) {
-              return
+              return;
             }
             //push entry
             entries.push({


### PR DESCRIPTION
Website will only show logs following our naming convention for outputted L10 tests (run_{SERVICE TAG}_{TIME}.log)
Closes: #86 