### PR TITLE
Changes that will track the status of a station

### DIFF
--- a/scripts/check_station.sh
+++ b/scripts/check_station.sh
@@ -30,7 +30,8 @@ if [ -z "$BASH_PID" ]; then
   printf '  "status": %d,\n'    "3"
   # escape any quotes in the message
   escaped_msg=${MESSAGE//\"/\\\"}
-  printf '  "message": "%s"\n'  "No existing tmux session for $NORMALIZED_NAME."
+  printf '  "message": "%s",\n'  "No existing tmux session for $NORMALIZED_NAME."
+  printf '  "details": null\n'
   printf '}\n'
   exit 1
 fi
@@ -50,7 +51,7 @@ fi
 
 
 
-
+DETAILS="null"
 NEWEST_CHILD=$(pgrep -P "$BASH_PID" -afn)
 if [ -z "$NEWEST_CHILD" ]; then
   
@@ -122,21 +123,39 @@ if [[ $(echo $pane | grep -c "logs are located at ") -gt 0 ]]; then
   fi
 fi
 
-if [ "$CODE" == "0" ]; then
-  ok=0
-  failed=0
-elif [ "$CODE" == "1" ]; then
-  ok=$(echo "$pane" | grep -c "Testing.*OK \[")
-  failed=$(echo "$pane" | grep -c "Testing.*FAILED \[")
+if [ "$CODE" == "1" ]; then
+  finished_tests=$(echo "$pane" | grep -P "(Testing|Dumping).*\[ [0-9]+\:[0-9]{2}s \]" | sed -E "s/^(Testing|Dumping) //g" | sed -E "s/ \[ [0-9]+\:[0-9]{2}s \]$//g")
+  test_current=$(echo "$pane" | grep -P "(Testing|Dumping)" | tail -n1 | sed -E "s/^(Testing|Dumping) //g" | sed -E "s/ .*$//g")
+  if [[ -n $test_current ]]; then
+    MESSAGE="$MESSAGE ($test_current)"
+    test_ok=$(echo "$finished_tests" | grep " OK$" | sed -E "s/ OK$//g")
+    test_fail=$(echo "$finished_tests" | grep " FAILED$" | sed -E "s/ FAILED$//g")
+    test_skip=$(echo "$finished_tests" | grep " SKIPPED$" | sed -E "s/ SKIPPED$//g")
+    test_timeout=$(echo "$finished_tests" | grep " TIMEOUT$" | sed -E "s/ TIMEOUT$//g")
+    details_json=()
+    details_json+=("\"CURRENT TEST\": \"$test_current\"")
+    if [[ -n $test_ok ]]; then
+      details_json+=("\"OK\": $(echo "$test_ok" | jq -R . | jq -s .)")
+    fi
+    if [[ -n $test_fail ]]; then
+      details_json+=("\"FAILED\": $(echo "$test_fail" | jq -R . | jq -s .)")
+    fi
+    if [[ -n $test_timeout ]]; then
+      details_json+=("\"TIMEOUT\": $(echo "$test_timeout" | jq -R . | jq -s .)")
+    fi
+    if [[ -n $test_skip ]]; then
+      details_json+=("\"SKIPPED\": $(echo "$test_skip" | jq -R . | jq -s .)")
+    fi
+    DETAILS=$(echo {$(IFS=", "; echo "${details_json[*]}")})
+  fi
 fi
 
 # emit JSON
 printf '{\n'
 printf '  "station": "%s",\n' "$NORMALIZED_NAME"
 printf '  "status": %d,\n'    "$CODE"
-printf '  "ok": %d,\n'        "$ok"
-printf '  "failed": %d, \n'   "$failed"
 # escape any quotes in the message
 escaped_msg=${MESSAGE//\"/\\\"}
-printf '  "message": "%s"\n'  "$escaped_msg"
+printf '  "message": "%s",\n'  "$escaped_msg"
+printf '  "details": %s\n'   "$DETAILS"
 printf '}\n'

--- a/scripts/station_status_json_gen.sh
+++ b/scripts/station_status_json_gen.sh
@@ -31,11 +31,12 @@ for st in "${stations[@]}"; do
     # parse fields
     status=$(echo "$output" | jq -r '.status')
     message=$(echo "$output" | jq -r '.message')
+    details=$(echo "$output" | jq -r '.details')
 
-    echo "  status=$status, message=\"$message\""
+    echo "  status=$status, message=\"$message\", details=$details"
 
-    payload=$(jq -nc --argjson status "$status" --arg message "$message" \
-      '{status: $status, message: $message}')
+    payload=$(jq -nc --argjson status "$status" --arg message "$message" --argjson details "$details"\
+      '{status: $status, message: $message, details: $details}')
 
     # PATCH to API
     curl -s -X PATCH "$API_URL/$st" \

--- a/website_backend/db_migrations/0007-station-details.sql
+++ b/website_backend/db_migrations/0007-station-details.sql
@@ -1,0 +1,3 @@
+-- Add details column which will be stored as a JSON string or string
+ALTER TABLE public.station
+    ADD COLUMN IF NOT EXISTS details TEXT;

--- a/website_backend/src/routes/stations.js
+++ b/website_backend/src/routes/stations.js
@@ -7,7 +7,7 @@ const router = express.Router();
 router.get("/", async (req, res) => {
   try {
     const { rows } = await db.query(`
-      SELECT s.id, s.station_name, s.status, s.message,
+      SELECT s.id, s.station_name, s.status, s.message, s.details::json AS details,
              s.system_id,
              s.last_updated,
              sys.service_tag AS system_service_tag
@@ -28,7 +28,7 @@ router.get("/:station_name", async (req, res) => {
   try {
     const { rows } = await db.query(
       `
-      SELECT s.id, s.station_name, s.status, s.message,
+      SELECT s.id, s.station_name, s.status, s.message, s.details::json AS details,
              s.system_id,
              s.last_updated,
              sys.service_tag AS system_service_tag
@@ -53,7 +53,7 @@ router.get("/:station_name", async (req, res) => {
 router.patch("/:station_name", async (req, res) => {
   const station_name = req.params.station_name;
   // Only these fields affect last_updated
-  const { system_id, status, message } = req.body;
+  const { system_id, status, message, details } = req.body;
 
   try {
     // 1) Load current values
@@ -80,6 +80,7 @@ router.patch("/:station_name", async (req, res) => {
       req.body,
       "message"
     );
+    const wantDetails = Object.prototype.hasOwnProperty.call(req.body, "details");
 
     if (wantSystem && system_id !== current.system_id) {
       updates.push(`system_id = $${i++}`);
@@ -92,6 +93,8 @@ router.patch("/:station_name", async (req, res) => {
     if (wantMessage && (message ?? "") !== (current.message ?? "")) {
       updates.push(`message = $${i++}`);
       values.push(message ?? "");
+      updates.push(`details = $${i++}`);
+      values.push(wantDetails ? details : "");
     }
 
     // Nothing really changed → return current state without bumping last_updated
@@ -110,7 +113,7 @@ router.patch("/:station_name", async (req, res) => {
       UPDATE station
          SET ${updates.join(", ")}
        WHERE station_name = $${i}
-       RETURNING station_name, system_id, status, message, last_updated
+       RETURNING station_name, system_id, status, message, details, last_updated
     `;
 
     const updRes = await db.query(sql, values);

--- a/website_frontend/src/components/Station.jsx
+++ b/website_frontend/src/components/Station.jsx
@@ -34,11 +34,41 @@ function Station({
     return now.diff(then, "minutes").minutes; // float
   }, [now, then]);
 
+  const details = stationInfo.details;
+  let details_text = "";
+
+  if (details) {
+    for (let key in details) {
+      if (key === "CURRENT TEST") {
+        details_text+=key+": "+details[key]+"\n\n";
+        continue;
+      }
+      details_text+=key+"\n";
+      details_text+=details[key].reduce((acc, e) => acc+e+"\n", "");
+      details_text+="\n";
+    }
+  }
+
   // Map elapsed minutes to a 0-100% progress, clamped
   const progressPct = useMemo(() => {
-    const pct = (minutesSince / progressWindowMin) * 100;
+    let passed = 0;
+    let total = 0;
+    if (details) {
+      if ("OK" in details) {
+        total += details.OK.length;
+        passed = details.OK.length;
+      }
+      if ("FAILED" in details) {
+        total += details.FAILED.length;
+      }
+      if ("TIMEOUT" in details) {
+        total += details.TIMEOUT.length;
+      }
+    }
+
+    const pct = total > 0? (passed / total) * 100 : (minutesSince / progressWindowMin) * 100;
     return Math.max(0, Math.min(100, pct));
-  }, [minutesSince, progressWindowMin]);
+  }, [minutesSince]);
 
   const humanAgo = useMemo(() => {
     if (!diff) return "";
@@ -50,10 +80,10 @@ function Station({
     if (m > 0) return `${m} minute${m > 1 ? "s" : ""} ago`;
     return "just now";
   }, [diff]);
-
+  
   const tooltip =
     stationInfo.status === 1 && then
-      ? `${progressPct.toFixed(1)}% • updated ${humanAgo}`
+      ? `${details_text}• updated ${humanAgo} •`
       : undefined;
 
   const renderStatus = (status, message) => {
@@ -93,6 +123,14 @@ function Station({
             className="absolute left-0 top-0 h-full bg-green-300/70"
             style={{
               width: `${progressPct}%`,
+              transition: "width 0.6s linear",
+            }}
+            aria-hidden="true"
+          />
+          <span
+            className="absolute right-0 top-0 h-full bg-red-300/70"
+            style={{
+              width: `${100 - progressPct}%`,
               transition: "width 0.6s linear",
             }}
             aria-hidden="true"


### PR DESCRIPTION
Closes: #92 
Tracks the passed, failed, timed out, and skipped tests when hovering over the progress bar
The progress bar now fills based on ratio of passed tests to failed tests (i.e. 80% filled with 4 passes and 1 fail)
Time last updated will also indicate how long a station has been running the current test

Makes changes to stations table, stations API endpoint, stations.jsx component, and check_station.sh and station_status_json_gen.sh scripts