### PR TITLE
changing backend PPID patch for L10

### DIFF
--- a/website_backend/src/routes/systems.js
+++ b/website_backend/src/routes/systems.js
@@ -4415,6 +4415,10 @@ router.patch("/:service_tag/ppid", authenticateToken, async (req, res) => {
     return res.status(400).json({ error: "ppid is required" });
   }
 
+  if (ppid.trim().toUpperCase() === service_tag.toUpperCase()) {
+    res.json({ message: "PPID provided matches service tag, skipping PPID update" });
+  }
+
   let parsed;
   try {
     parsed = parseAndValidatePPID(ppid);


### PR DESCRIPTION
Some systems have service tag as their PPID
Change backend check to skip updating the PPID if this is the case
Closes: #135 