### PR TITLE
see PR

### DIFF
--- a/website_backend/db_migrations/0013-add-bianca-side-root-causes.sql
+++ b/website_backend/db_migrations/0013-add-bianca-side-root-causes.sql
@@ -1,0 +1,22 @@
+-- 0013-add-bianca-side-root-causes.sql
+-- Rename the existing Bianca Failure root cause and add side-specific variants.
+
+UPDATE public.root_cause
+SET name = 'Bianca Failure (Side Unknown)'
+WHERE LOWER(name) = LOWER('Bianca Failure');
+
+INSERT INTO public.root_cause (name)
+SELECT 'Left Bianca Failure'
+WHERE NOT EXISTS (
+  SELECT 1
+  FROM public.root_cause
+  WHERE LOWER(name) = LOWER('Left Bianca Failure')
+);
+
+INSERT INTO public.root_cause (name)
+SELECT 'Right Bianca Failure'
+WHERE NOT EXISTS (
+  SELECT 1
+  FROM public.root_cause
+  WHERE LOWER(name) = LOWER('Right Bianca Failure')
+);

--- a/website_backend/src/routes/systems.js
+++ b/website_backend/src/routes/systems.js
@@ -4927,6 +4927,49 @@ router.patch("/:service_tag/issue", authenticateToken, async (req, res) => {
   }
 });
 
+// POST /api/v1/systems/:service_tag/note
+router.post("/:service_tag/note", authenticateToken, async (req, res) => {
+  const { service_tag } = req.params;
+  const note = String(req.body?.note || "").trim();
+
+  if (!note) {
+    return res.status(400).json({ error: "note is required" });
+  }
+
+  const client = await db.connect();
+  try {
+    await client.query("BEGIN");
+
+    const systemRes = await client.query(
+      `SELECT id, location_id FROM system WHERE service_tag = $1 LIMIT 1`,
+      [service_tag],
+    );
+
+    if (!systemRes.rows.length) {
+      await client.query("ROLLBACK");
+      return res.status(404).json({ error: "System not found" });
+    }
+
+    const { id: system_id, location_id } = systemRes.rows[0];
+
+    await client.query(
+      `INSERT INTO system_location_history
+         (system_id, from_location_id, to_location_id, note, moved_by)
+       VALUES ($1, $2, $3, $4, $5)`,
+      [system_id, location_id, location_id, note, req.user.userId],
+    );
+
+    await client.query("COMMIT");
+    return res.json({ message: "Note added" });
+  } catch (err) {
+    await client.query("ROLLBACK");
+    console.error(err);
+    return res.status(500).json({ error: "Failed to add note" });
+  } finally {
+    client.release();
+  }
+});
+
 // PATCH /api/v1/systems/:service_tag/rack
 router.patch("/:service_tag/rack", authenticateToken, async (req, res) => {
   const { service_tag } = req.params;

--- a/website_frontend/src/App.jsx
+++ b/website_frontend/src/App.jsx
@@ -56,10 +56,10 @@ function App() {
   }, [location.pathname, location.search, location.hash]);
 
   return (
-    <>
-      <div className="bg-gray-100 min-h-screen text-gray-800 font-roboto pb-10">
-        {/* <ScrollToTop /> */}
-        <Header />
+    <div className="bg-gray-100 min-h-screen overflow-hidden text-gray-800 font-roboto">
+      {/* <ScrollToTop /> */}
+      <Header />
+      <div className="pb-10">
         <Routes>
           <Route path="/" element={<TrackingPage />} />
           <Route path="/stations" element={<StationPage />} />
@@ -89,7 +89,7 @@ function App() {
         </Routes>
       </div>
       <Footer className="mt-10" />
-    </>
+    </div>
   );
 }
 

--- a/website_frontend/src/components/Footer.jsx
+++ b/website_frontend/src/components/Footer.jsx
@@ -75,11 +75,24 @@ function Footer({ className = "" }) {
     import.meta.env.VITE_BUILD_NUMBER ||
     import.meta.env.BUILD_NUMBER ||
     "unknown";
+  const clearPendingRefresh = () => {
+    refreshPendingRef.current = false;
+    setRefreshPending(false);
+    logAutoRefresh(
+      AUTO_REFRESH_DEBUG_LOGGING,
+      "refresh-queue-cleared",
+      {
+        reason: "page-context-reset",
+        timestamp: new Date().toISOString(),
+      },
+    );
+  };
 
   useEffect(() => {
     const storageKey = buildLastUpdateStorageKey(location.pathname);
     const stored = Number(sessionStorage.getItem(storageKey));
     setLastUpdatedAt(Number.isFinite(stored) && stored > 0 ? stored : null);
+    clearPendingRefresh();
   }, [location.pathname]);
 
   // 1) Get server timezone once
@@ -120,6 +133,7 @@ function Footer({ className = "" }) {
         String(timestamp),
       );
       setLastUpdatedAt(timestamp);
+      clearPendingRefresh();
       logAutoRefresh(AUTO_REFRESH_DEBUG_LOGGING, "page-data-updated", {
         pathname: location.pathname,
         endpoint: detail.endpoint || null,
@@ -162,6 +176,7 @@ function Footer({ className = "" }) {
   }, []);
 
   // 4) Refresh the app on a timer, but only once the user has been idle.
+  // The 5-minute timer is anchored to the last successful data fetch.
   useEffect(() => {
     const setPendingRefresh = (value) => {
       refreshPendingRef.current = value;
@@ -217,11 +232,23 @@ function Footer({ className = "" }) {
       auto_refresh_ms: AUTO_REFRESH_MS,
       user_idle_ms: USER_IDLE_MS,
       retry_ms: REFRESH_RETRY_MS,
+      last_updated_at: lastUpdatedAt
+        ? new Date(lastUpdatedAt).toISOString()
+        : null,
     });
 
-    const autoRefreshId = setInterval(
-      () => refreshIfIdle("auto-interval"),
-      AUTO_REFRESH_MS,
+    const msUntilNextRefresh = Number.isFinite(lastUpdatedAt) && lastUpdatedAt > 0
+      ? Math.max(0, lastUpdatedAt + AUTO_REFRESH_MS - Date.now())
+      : AUTO_REFRESH_MS;
+
+    logAutoRefresh(AUTO_REFRESH_DEBUG_LOGGING, "refresh-scheduled", {
+      delay_ms: msUntilNextRefresh,
+      based_on_last_updated: Number.isFinite(lastUpdatedAt) && lastUpdatedAt > 0,
+    });
+
+    const autoRefreshId = setTimeout(
+      () => refreshIfIdle("auto-timeout"),
+      msUntilNextRefresh,
     );
     const retryId = setInterval(() => {
       if (refreshPendingRef.current) {
@@ -230,13 +257,13 @@ function Footer({ className = "" }) {
     }, REFRESH_RETRY_MS);
 
     return () => {
-      clearInterval(autoRefreshId);
+      clearTimeout(autoRefreshId);
       clearInterval(retryId);
       logAutoRefresh(AUTO_REFRESH_DEBUG_LOGGING, "refresh-system-stopped", {
         timestamp: new Date().toISOString(),
       });
     };
-  }, []);
+  }, [lastUpdatedAt]);
 
   // 5) Compute display time from client's UTC -> server zone.
   // Reading tick keeps these values moving once per second.

--- a/website_frontend/src/components/Station.jsx
+++ b/website_frontend/src/components/Station.jsx
@@ -99,7 +99,6 @@ function Station({
         show={!!tooltip}
         text={<span className="whitespace-pre-line">{tooltip}</span>}
         maxWidthClassName="max-w-[22rem] sm:max-w-sm"
-        zIndexClassName="z-1"
         topViewportOffset={110}
       >
         {statusBadge}

--- a/website_frontend/src/components/Tooltip.jsx
+++ b/website_frontend/src/components/Tooltip.jsx
@@ -6,7 +6,7 @@ export default function Tooltip({
   position = "top",
   show = false,
   maxWidthClassName = "max-w-xs",
-  zIndexClassName = "z-0",
+  zIndexClassName = "z-5",
   autoFlip = true,
   topViewportOffset = 0,
   bottomViewportOffset = 0,
@@ -83,7 +83,15 @@ export default function Tooltip({
       window.removeEventListener("resize", updatePosition);
       window.removeEventListener("scroll", updatePosition, true);
     };
-  }, [autoFlip, bottomViewportOffset, open, position, show, text, topViewportOffset]);
+  }, [
+    autoFlip,
+    bottomViewportOffset,
+    open,
+    position,
+    show,
+    text,
+    topViewportOffset,
+  ]);
 
   if (!show || !text) {
     return <>{children}</>;

--- a/website_frontend/src/hooks/useApi.jsx
+++ b/website_frontend/src/hooks/useApi.jsx
@@ -236,6 +236,13 @@ function useApi() {
       body: JSON.stringify(payload),
     });
 
+  const addSystemNote = (tag, note) =>
+    fetchJSON(`/systems/${encodeURIComponent(tag)}/note`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ note }),
+    });
+
   // list all categories
   const getRootCauses = () => fetchJSON(`/systems/root-cause`);
 
@@ -1012,6 +1019,7 @@ function useApi() {
     createPartItem,
     updatePartItem,
     deletePartItem,
+    addSystemNote,
     getRootCauses,
     getRootCauseSubCategories,
     getTags,

--- a/website_frontend/src/pages/SystemPage.jsx
+++ b/website_frontend/src/pages/SystemPage.jsx
@@ -244,6 +244,8 @@ function SystemPage() {
       return Number.isFinite(photoMs) && photoMs > latestReceivedMs;
     });
   }, [latestReceivedAt, photos]);
+  const hasSystemFolderEvidence =
+    Number(system?.l10_logs_total_size_bytes || 0) > 0;
 
   const { token } = useContext(AuthContext);
   const canAddPhoto = !isResolved && !!token;
@@ -278,6 +280,7 @@ function SystemPage() {
     getSystemHistory,
     deleteSystem,
     getSystems,
+    addSystemNote,
     updateSystemLocation,
     deleteLastHistoryEntry,
     getStations,
@@ -387,7 +390,7 @@ function SystemPage() {
   ];
   const ROOT_CAUSE_CATEGORY_RULES_BY_LOCATION = {
     "RMA PID": {
-      allowedCategoryIds: ["14", "15", "9", "3", "2", "16"],
+      allowedCategoryIds: ["14", "15", "9", "3", "2", "16", "19", "20"],
     },
   };
   const ROOT_CAUSE_SUBCATEGORY_RULES_BY_LOCATION = {
@@ -403,6 +406,11 @@ function SystemPage() {
         allowedSubCategoryIds: ["2", "3", "5"],
       },
     ],
+  };
+  const ROOT_CAUSE_SUBCATEGORY_RULES_BY_ROOT_CAUSE = {
+    8: {
+      allowedSubCategoryIds: ["1", "4"],
+    },
   };
 
   const applyRootCauseCategoryLocationRule = (options, locationName) => {
@@ -427,6 +435,17 @@ function SystemPage() {
     if (!matchedRule?.allowedSubCategoryIds?.length) return options;
 
     const allowedIds = new Set(matchedRule.allowedSubCategoryIds.map(String));
+    return options.filter((opt) => allowedIds.has(String(opt.value)));
+  };
+
+  const applyRootCauseSubCategoryRootCauseRule = (options, categoryId) => {
+    if (categoryId == null) return options;
+
+    const rule =
+      ROOT_CAUSE_SUBCATEGORY_RULES_BY_ROOT_CAUSE[String(categoryId)] || null;
+    if (!rule?.allowedSubCategoryIds?.length) return options;
+
+    const allowedIds = new Set(rule.allowedSubCategoryIds.map(String));
     return options.filter((opt) => allowedIds.has(String(opt.value)));
   };
 
@@ -730,6 +749,10 @@ function SystemPage() {
           toLocationName,
           selectedRootCauseId,
         );
+        subOpts = applyRootCauseSubCategoryRootCauseRule(
+          subOpts,
+          selectedRootCauseId,
+        );
 
         // Clear selections if they’re no longer valid
         if (
@@ -912,9 +935,7 @@ function SystemPage() {
       try {
         const res = await getL11LogReconciliationMode();
         if (!cancelled) {
-          setL11LogReconciliationMode(
-            !!res?.l11_log_reconciliation_mode,
-          );
+          setL11LogReconciliationMode(!!res?.l11_log_reconciliation_mode);
         }
       } catch {
         if (!cancelled) setL11LogReconciliationMode(false);
@@ -1535,6 +1556,10 @@ function SystemPage() {
 
   useEffect(() => {
     fetchData();
+  }, [serviceTag]);
+
+  useEffect(() => {
+    setLogsDir("");
   }, [serviceTag]);
 
   useEffect(() => {
@@ -2626,30 +2651,15 @@ function SystemPage() {
       }
 
       // D) For any donor systems involved in unit↔unit part moves, write a note
-      // using their current location as the "to" location (no actual move).
+      // without changing their location or pallet assignment.
       if (Object.keys(donorLocationNotes).length > 0) {
         await Promise.all(
           Object.entries(donorLocationNotes).map(async ([donorTag, lines]) => {
-            const donor = donorSystems.find(
-              (u) =>
-                (u.service_tag || "").toUpperCase() === donorTag.toUpperCase(),
-            );
-
-            const donorLocName = donor?.location || "Received";
-            const donorLocId =
-              locations.find((l) => l.name === donorLocName)?.id ||
-              locations.find((l) => l.name === "Received")?.id;
-
-            if (!donorLocId) return;
-
             const donorNote =
               `Parts transaction with ${system.service_tag}:\n` +
               lines.join(" ");
 
-            await updateSystemLocation(donorTag, {
-              to_location_id: donorLocId,
-              note: donorNote,
-            });
+            await addSystemNote(donorTag, donorNote);
           }),
         );
       }
@@ -3245,6 +3255,13 @@ function SystemPage() {
                         ).map((loc) => {
                           const isRMA = RMA_LOCATION_IDS.includes(loc.id);
                           const isRmaCid = loc.name === "RMA CID";
+                          const evidenceRequiredBlockedDestinations = new Set([
+                            "RMA VID",
+                            "RMA PID",
+                            "Sent to L11",
+                          ]);
+                          const isEvidenceRequiredDestination =
+                            evidenceRequiredBlockedDestinations.has(loc.name);
                           const isL10 = L10_LOCATION_ID
                             ? loc.id === L10_LOCATION_ID
                             : loc.name === "In L10";
@@ -3254,6 +3271,9 @@ function SystemPage() {
                           const rmaBlocked = isRMA && willHaveGoodAfterSubmit;
                           const cidPhotoBlocked =
                             isRmaCid && !hasFreshPhotoEvidenceForCid;
+                          const evidenceBlocked =
+                            isEvidenceRequiredDestination &&
+                            !hasSystemFolderEvidence;
                           const pendingL11GoodPartsBlocked =
                             isPendingL11Destination && willHaveGoodAfterSubmit;
                           // Allow In L10 when at least one bad has a Replacement PPID chosen
@@ -3267,6 +3287,7 @@ function SystemPage() {
                             isResolved ||
                             rmaBlocked ||
                             cidPhotoBlocked ||
+                            evidenceBlocked ||
                             l10Blocked ||
                             l11Blocked ||
                             pendingL11GoodPartsBlocked;
@@ -3277,13 +3298,15 @@ function SystemPage() {
                               ? "Remove/return all good parts before moving to an RMA location."
                               : cidPhotoBlocked
                                 ? "Photo evidence of the damage must be uploaded before moving to RMA CID."
-                                : pendingL11GoodPartsBlocked
-                                  ? "Return/remove all good parts before moving to Pending L11 Logs"
-                                  : l10Blocked
-                                    ? "Add a Replacement PPID for at least one defective part to move to In L10."
-                                    : isResolved
-                                      ? "Resolved units can’t be moved."
-                                      : undefined;
+                                : evidenceBlocked
+                                  ? "Evidence must be added before moving to this location."
+                                  : pendingL11GoodPartsBlocked
+                                    ? "Return/remove all good parts before moving to Pending L11 Logs"
+                                    : l10Blocked
+                                      ? "Add a Replacement PPID for at least one defective part to move to In L10."
+                                      : isResolved
+                                        ? "Resolved units can’t be moved."
+                                        : undefined;
 
                           return (
                             <Tooltip
@@ -4500,12 +4523,12 @@ function SystemPage() {
                                       </p>
                                     )}
 
-                                    {showSingleUnitMsgActive && (
+                                    {/* {showSingleUnitMsgActive && (
                                       <p className="italic">
                                         Original part will be moved back into
                                         this unit when you submit.
                                       </p>
-                                    )}
+                                    )} */}
 
                                     {showSingleUnitMsgInactive && (
                                       <p className="italic">
@@ -4664,7 +4687,7 @@ function SystemPage() {
                       <div
                         className={`w-full lg:w-3/5 rounded border border-gray-300`}
                       >
-                        <table className="rounded w-full bg-white  shadow-sm overflow-hidden ">
+                        <table className="rounded w-full bg-white  shadow-sm ">
                           <thead>
                             <tr>
                               <th className="bg-gray-50 font-semibold uppercase text-xs text-gray-600 p-3">


### PR DESCRIPTION
closes #148 

1. RMA VID”, “RMA PID”, and “Sent to L11” are now greyed out when there is no evidence added to the system folder with a tooltip that evidence needs to be added.
2. “Left Bianca Failure” and “Right Bianca Failure” added to the root cause options
3. “Bianca Failure” changed to “Bianca Issue (Side Unknown)” for more accurate root cause.
4. "Coolant Failure" root cause only has "Unable to Repair" and "Assembly issue" as the sub categories
5. "Refresh queued until user is idle" now resets when changing tabs or last updated is reset
6. Fix various Z index issues related to the new tooltips
7. Fixed bug where tooltip would create whitespace below the footer when its length went beyond the page.
8. Fixed bug where when you add good part from unit, and the unit is in RMA pallet, it changes the pallet number
9. Fix issue when you're in a sub dir in the logs tab and you go directly to another service tag, it shows nothing because the state is still set to the old sub dir name for the old service tag 