### PR TITLE
feat-155: pending MRB, pending L11 move rule, rack tag validation, an…

### DIFF
--- a/dev_backend_deploy.sh
+++ b/dev_backend_deploy.sh
@@ -66,9 +66,9 @@ EOF
 
 cmd="${1:-}"
 
-# Load config (supports optional 9th field: source_prod)
+# Load config (supports optional 10th field: deploy_mode)
 declare -A HOST DIR PROJ PORT FRONTEND IS_DEV LOCKFILE SOURCE_PROD
-while IFS='|' read -r name host dir proj port frontend is_dev lockfile source_prod; do
+while IFS='|' read -r name host dir proj port frontend is_dev lockfile source_prod deploy_mode _ignored_extra || [[ -n "${name:-}" ]]; do
   [[ -z "${name// }" ]] && continue
   [[ "$name" =~ ^# ]] && continue
 

--- a/dev_frontend_deploy.sh
+++ b/dev_frontend_deploy.sh
@@ -62,9 +62,9 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-# Load config (supports optional 9th field: source_prod)
+# Load config (supports optional 10th field: deploy_mode)
 declare -A HOST FRONTEND IS_DEV SOURCE_PROD
-while IFS='|' read -r name host dir proj port frontend_url is_dev lockfile source_prod; do
+while IFS='|' read -r name host dir proj port frontend_url is_dev lockfile source_prod deploy_mode _ignored_extra || [[ -n "${name:-}" ]]; do
   [[ -z "${name// }" ]] && continue
   [[ "$name" =~ ^# ]] && continue
 

--- a/website_backend/db_migrations/0014-add-pending-l11-move-rule-setting.sql
+++ b/website_backend/db_migrations/0014-add-pending-l11-move-rule-setting.sql
@@ -1,0 +1,18 @@
+-- 0014-add-pending-l11-move-rule-setting.sql
+-- Add global setting to delay moves into Pending L11 Logs after returning to Received.
+
+CREATE TABLE IF NOT EXISTS public.global_settings (
+  key TEXT PRIMARY KEY,
+  value_json JSONB NOT NULL,
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+INSERT INTO public.global_settings (key, value_json)
+SELECT
+  'pending_l11_move_rule',
+  '{"enabled": false, "minutes": 30}'::jsonb
+WHERE NOT EXISTS (
+  SELECT 1
+  FROM public.global_settings
+  WHERE key = 'pending_l11_move_rule'
+);

--- a/website_backend/db_migrations/0015-add-pending-mrb-location.sql
+++ b/website_backend/db_migrations/0015-add-pending-mrb-location.sql
@@ -1,0 +1,10 @@
+-- 0015-add-pending-mrb-location.sql
+-- Add Pending MRB location.
+
+INSERT INTO public.location (name)
+SELECT 'Pending MRB'
+WHERE NOT EXISTS (
+  SELECT 1
+  FROM public.location
+  WHERE LOWER(name) = LOWER('Pending MRB')
+);

--- a/website_backend/init-db/init.sql
+++ b/website_backend/init-db/init.sql
@@ -15,7 +15,8 @@ INSERT INTO location (name) VALUES
 ('RMA CID'),
 ('RMA PID'),
 ('Sent to L11'),
-('Sent for Dell Repair');
+('Sent for Dell Repair'),
+('Pending MRB');
 
 -- 📄 Create users table
 CREATE TABLE users (
@@ -37,6 +38,12 @@ VALUES ('deleted_user@example.com', '');
 
 INSERT INTO global_settings (key, value_json)
 VALUES ('repairs_allowed', 'true'::jsonb);
+
+INSERT INTO global_settings (key, value_json)
+VALUES (
+  'pending_l11_move_rule',
+  '{"enabled": false, "minutes": 30}'::jsonb
+);
 
 -- 📄 Create factory table
 CREATE TABLE factory (

--- a/website_backend/src/routes/server.js
+++ b/website_backend/src/routes/server.js
@@ -7,6 +7,11 @@ const router = express.Router();
 
 const REPAIRS_ALLOWED_KEY = "repairs_allowed";
 const L11_LOG_RECONCILIATION_MODE_KEY = "l11_log_reconciliation_mode";
+const PENDING_L11_MOVE_RULE_KEY = "pending_l11_move_rule";
+const DEFAULT_PENDING_L11_MOVE_RULE = {
+  enabled: false,
+  minutes: 30,
+};
 
 async function getBooleanSettingValue(key, defaultValue) {
   const { rows } = await db.query(
@@ -39,12 +44,59 @@ async function upsertBooleanSettingValue(key, value) {
     : !!rows[0]?.value_json;
 }
 
+function normalizePendingL11MoveRule(value) {
+  const raw = value && typeof value === "object" ? value : {};
+  const parsedMinutes = Number.parseInt(raw.minutes, 10);
+  const minutes = Number.isInteger(parsedMinutes) && parsedMinutes > 0
+    ? parsedMinutes
+    : DEFAULT_PENDING_L11_MOVE_RULE.minutes;
+
+  return {
+    enabled: !!raw.enabled,
+    minutes,
+  };
+}
+
+async function getJsonSettingValue(key, defaultValue) {
+  const { rows } = await db.query(
+    `SELECT value_json FROM global_settings WHERE key = $1 LIMIT 1`,
+    [key],
+  );
+  if (!rows.length) return defaultValue;
+  return rows[0]?.value_json ?? defaultValue;
+}
+
+async function upsertJsonSettingValue(key, value) {
+  const { rows } = await db.query(
+    `
+    INSERT INTO global_settings (key, value_json, updated_at)
+    VALUES ($1, $2::jsonb, NOW())
+    ON CONFLICT (key)
+    DO UPDATE SET
+      value_json = EXCLUDED.value_json,
+      updated_at = NOW()
+    RETURNING value_json
+    `,
+    [key, JSON.stringify(value)],
+  );
+
+  return rows[0]?.value_json ?? value;
+}
+
 async function getRepairsAllowedValue() {
   return getBooleanSettingValue(REPAIRS_ALLOWED_KEY, true);
 }
 
 async function getL11LogReconciliationModeValue() {
   return getBooleanSettingValue(L11_LOG_RECONCILIATION_MODE_KEY, false);
+}
+
+async function getPendingL11MoveRuleValue() {
+  const value = await getJsonSettingValue(
+    PENDING_L11_MOVE_RULE_KEY,
+    DEFAULT_PENDING_L11_MOVE_RULE,
+  );
+  return normalizePendingL11MoveRule(value);
 }
 
 // API route for server time and CST/CDT
@@ -159,6 +211,62 @@ router.patch(
       return res
         .status(500)
         .json({ error: "Failed to update l11_log_reconciliation_mode" });
+    }
+  },
+);
+
+router.get(
+  "/pending_l11_move_rule",
+  async (_req, res) => {
+    try {
+      const pending_l11_move_rule = await getPendingL11MoveRuleValue();
+      return res.json({ pending_l11_move_rule });
+    } catch (err) {
+      console.error("Failed to fetch pending_l11_move_rule:", err);
+      return res
+        .status(500)
+        .json({ error: "Failed to fetch pending_l11_move_rule" });
+    }
+  },
+);
+
+router.patch(
+  "/pending_l11_move_rule",
+  authenticateToken,
+  ensureAdmin,
+  async (req, res) => {
+    const pendingL11MoveRule = req.body?.pending_l11_move_rule;
+    const enabled = pendingL11MoveRule?.enabled;
+    const parsedMinutes = Number.parseInt(pendingL11MoveRule?.minutes, 10);
+
+    if (typeof enabled !== "boolean") {
+      return res.status(400).json({
+        error: "pending_l11_move_rule.enabled must be a boolean",
+      });
+    }
+
+    if (!Number.isInteger(parsedMinutes) || parsedMinutes <= 0) {
+      return res.status(400).json({
+        error: "pending_l11_move_rule.minutes must be a positive integer",
+      });
+    }
+
+    try {
+      const value = await upsertJsonSettingValue(
+        PENDING_L11_MOVE_RULE_KEY,
+        normalizePendingL11MoveRule({
+          enabled,
+          minutes: parsedMinutes,
+        }),
+      );
+      return res.json({
+        pending_l11_move_rule: normalizePendingL11MoveRule(value),
+      });
+    } catch (err) {
+      console.error("Failed to update pending_l11_move_rule:", err);
+      return res
+        .status(500)
+        .json({ error: "Failed to update pending_l11_move_rule" });
     }
   },
 );

--- a/website_backend/src/routes/systems.js
+++ b/website_backend/src/routes/systems.js
@@ -224,6 +224,27 @@ async function getLatestReceivedAt(client, systemId) {
   return rows[0]?.changed_at || null;
 }
 
+function normalizePendingL11MoveRule(value) {
+  const raw = value && typeof value === "object" ? value : {};
+  const parsedMinutes = Number.parseInt(raw.minutes, 10);
+  const minutes = Number.isInteger(parsedMinutes) && parsedMinutes > 0
+    ? parsedMinutes
+    : DEFAULT_PENDING_L11_MOVE_RULE.minutes;
+
+  return {
+    enabled: !!raw.enabled,
+    minutes,
+  };
+}
+
+async function getPendingL11MoveRule(client) {
+  const { rows } = await client.query(
+    `SELECT value_json FROM global_settings WHERE key = $1 LIMIT 1`,
+    [PENDING_L11_MOVE_RULE_KEY],
+  );
+  return normalizePendingL11MoveRule(rows[0]?.value_json);
+}
+
 // Helper: fetch deleted user id
 async function getDeletedUserId() {
   const result = await db.query(
@@ -237,6 +258,17 @@ const RMA_LOCATION_IDS = [6, 7, 8];
 const RMA_CID_LOCATION_ID = 7;
 const RESOLVED_LOCATION_IDS = [6, 7, 8, 9, 10];
 const RECEIVED_LOCATION_ID = 1;
+const PENDING_L11_LOGS_LOCATION_ID = 3;
+const PENDING_MRB_LOCATION_NAME = "Pending MRB";
+const PENDING_L11_MOVE_RULE_KEY = "pending_l11_move_rule";
+const DEFAULT_PENDING_L11_MOVE_RULE = {
+  enabled: false,
+  minutes: 30,
+};
+
+function isPendingMrbLocationName(name) {
+  return String(name || "").trim() === PENDING_MRB_LOCATION_NAME;
+}
 const PHOTO_UPLOAD_ROOT = process.env.L10_LOGS_ROOT || "/var/www/html/l10_logs";
 const MAX_PHOTO_BYTES = 12 * 1024 * 1024; // 12MB
 const MAX_L11_LOG_BYTES = 250 * 1024 * 1024; // 250MB per file
@@ -1133,6 +1165,97 @@ function parseAndValidatePPID(ppidRaw) {
   if (!/^[A-Z0-9]{3}$/.test(rev)) throw new Error("Invalid revision format");
 
   return { ppid, dpn, factoryCodeRaw, manufacturedDate, serial, rev };
+}
+
+function validateRackServiceTag(rackServiceTagRaw) {
+  const rackUpper = String(rackServiceTagRaw || "")
+    .trim()
+    .toUpperCase();
+  const genericInvalidError =
+    "Please provide a valid Rack Service Tag, not a filler value";
+
+  if (rackUpper.length !== 7) {
+    return "Rack Service Tag must be exactly 7 characters long";
+  }
+
+  if (!/^[A-Z0-9]{7}$/.test(rackUpper)) {
+    return genericInvalidError;
+  }
+
+  if (!/[A-Z]/.test(rackUpper)) {
+    return genericInvalidError;
+  }
+
+  if (!/[0-9]$/.test(rackUpper)) {
+    return genericInvalidError;
+  }
+
+  const fillerTokens = [
+    "UNK",
+    "UNKN",
+    "N/A",
+    "NA",
+    "NONE",
+    "NULL",
+    "(NULL)",
+    "NODATA",
+    "NOINFO",
+    "TBD",
+    "TBA",
+    "N/R",
+    "BLANK",
+    "???",
+    "XXX",
+    "COOLANT",
+  ];
+
+  const manualBlocklist = new Set([
+    "1234567",
+    "2345678",
+    "COOLEAK",
+    "CWNC",
+    "COREWEAVENC",
+    "PHYSDMG",
+    "BADPALL",
+    "UNSURE",
+    "NOTGIVEN",
+  ]);
+
+  const rackForMatch = rackUpper.replace(/[\s/.-]/g, "");
+  const hasFiller = fillerTokens.some((tok) => rackForMatch.includes(tok));
+  if (hasFiller || manualBlocklist.has(rackForMatch)) {
+    return genericInvalidError;
+  }
+
+  const hasSequentialRun = (chunk, charset) => {
+    const indexes = [...chunk].map((ch) => charset.indexOf(ch));
+    if (indexes.some((idx) => idx === -1)) return false;
+    const len = charset.length;
+    const ascending = indexes
+      .slice(1)
+      .every((value, i) => value === (indexes[i] + 1) % len);
+    const descending = indexes
+      .slice(1)
+      .every((value, i) => value === (indexes[i] - 1 + len) % len);
+    return ascending || descending;
+  };
+
+  const containsSequentialFour = (value) => {
+    const alpha = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+    const digits = "0123456789";
+    for (let i = 0; i <= value.length - 4; i += 1) {
+      const chunk = value.slice(i, i + 4);
+      if (hasSequentialRun(chunk, alpha)) return true;
+      if (hasSequentialRun(chunk, digits)) return true;
+    }
+    return false;
+  };
+
+  if (containsSequentialFour(rackUpper)) {
+    return genericInvalidError;
+  }
+
+  return null;
 }
 
 /**
@@ -3485,43 +3608,10 @@ router.post("/", authenticateToken, async (req, res) => {
         "Service Tag, Location, PPID, Rack Service Tag, Host MAC, and BMC MAC are required",
     });
   }
-  // normalize rack id
   const rackUpper = rack_service_tag.trim().toUpperCase();
-
-  // 1) must be exactly 7 chars
-  if (rackUpper.length !== 7) {
-    return res.status(400).json({
-      error: "Rack Service Tag must be exactly 7 characters long",
-    });
-  }
-
-  // 2) must NOT contain common filler words
-  const fillerTokens = [
-    "UNK",
-    "UNKN",
-    "N/A",
-    "NA",
-    "NONE",
-    "NULL",
-    "(NULL)",
-    "NODATA",
-    "NOINFO",
-    "TBD",
-    "TBA",
-    "N/R",
-    "BLANK",
-    "???",
-    "XXX",
-    "COOLANT",
-  ];
-
-  // to make matching easier, remove spaces and slashes for the check
-  const rackForMatch = rackUpper.replace(/[\s/.-]/g, "");
-  const hasFiller = fillerTokens.some((tok) => rackForMatch.includes(tok));
-  if (hasFiller) {
-    return res.status(400).json({
-      error: "Please provide a valid Rack Service Tag, not a filler value",
-    });
+  const rackValidationError = validateRackServiceTag(rackUpper);
+  if (rackValidationError) {
+    return res.status(400).json({ error: rackValidationError });
   }
 
   let parsed;
@@ -4735,11 +4825,57 @@ router.patch("/:service_tag/location", authenticateToken, async (req, res) => {
       serial,
       rev,
     } = rows[0];
+    const targetLocationResult = await client.query(
+      `SELECT name FROM location WHERE id = $1 LIMIT 1`,
+      [targetLocationId],
+    );
+    const targetLocationName = targetLocationResult.rows[0]?.name || "";
 
     let receivedAt = null;
 
-    // Moving into a resolved location requires new logs since latest Received.
-    if (RESOLVED_LOCATION_IDS.includes(targetLocationId)) {
+    if (targetLocationId === PENDING_L11_LOGS_LOCATION_ID) {
+      const pendingL11MoveRule = await getPendingL11MoveRule(client);
+
+      if (pendingL11MoveRule.enabled) {
+        const latestReceivedAt = await getLatestReceivedAt(client, system_id);
+
+        if (!latestReceivedAt) {
+          await client.query("ROLLBACK");
+          return res.status(400).json({
+            error:
+              "Cannot move into Pending L11 Logs: no Received timestamp found for this system.",
+          });
+        }
+
+        const receivedMs = new Date(latestReceivedAt).getTime();
+        const elapsedMs = Date.now() - receivedMs;
+        const requiredMs = pendingL11MoveRule.minutes * 60 * 1000;
+
+        if (!Number.isFinite(receivedMs)) {
+          await client.query("ROLLBACK");
+          return res.status(400).json({
+            error:
+              "Cannot move into Pending L11 Logs: the latest Received timestamp is invalid.",
+          });
+        }
+
+        if (elapsedMs < requiredMs) {
+          const remainingMinutes = Math.ceil(
+            (requiredMs - Math.max(0, elapsedMs)) / 60000,
+          );
+          await client.query("ROLLBACK");
+          return res.status(400).json({
+            error: `Need to wait ${remainingMinutes} more minute(s) before moving into Pending L11 Logs so that any pending log downloads from MFT can complete.`,
+          });
+        }
+      }
+    }
+
+    // Moving into a resolved location or Pending MRB requires new evidence since latest Received.
+    if (
+      RESOLVED_LOCATION_IDS.includes(targetLocationId) ||
+      isPendingMrbLocationName(targetLocationName)
+    ) {
       const latestReceived = await client.query(
         `
         SELECT changed_at
@@ -4775,12 +4911,17 @@ router.patch("/:service_tag/location", authenticateToken, async (req, res) => {
       if (!hasNewFile) {
         await client.query("ROLLBACK");
         return res.status(400).json({
-          error: "Add evidence (logs or photos) before resolving this unit.",
+          error: isPendingMrbLocationName(targetLocationName)
+            ? "Add evidence (logs or photos) before moving to Pending MRB."
+            : "Add evidence (logs or photos) before resolving this unit.",
         });
       }
     }
 
-    if (targetLocationId === RMA_CID_LOCATION_ID) {
+    if (
+      targetLocationId === RMA_CID_LOCATION_ID ||
+      isPendingMrbLocationName(targetLocationName)
+    ) {
       const stSegment = safeServiceTagSegment(service_tag);
       const photosDir =
         PHOTO_UPLOAD_ROOT && stSegment
@@ -4792,7 +4933,9 @@ router.patch("/:service_tag/location", authenticateToken, async (req, res) => {
       if (!hasFreshPhotoEvidence) {
         await client.query("ROLLBACK");
         return res.status(400).json({
-          error: "Photo evidence of the damage must be uploaded before RMA CID.",
+          error: isPendingMrbLocationName(targetLocationName)
+            ? "Photo evidence of the damage must be uploaded before Pending MRB."
+            : "Photo evidence of the damage must be uploaded before RMA CID.",
         });
       }
     }
@@ -4805,6 +4948,26 @@ router.patch("/:service_tag/location", authenticateToken, async (req, res) => {
         error:
           "System is on a locked pallet — location changes are not allowed",
       });
+    }
+
+    if (targetLocationName === PENDING_MRB_LOCATION_NAME) {
+      const trackedBadParts = await client.query(
+        `
+        SELECT COUNT(*)::int AS count
+        FROM part_list
+        WHERE unit_id = $1
+          AND is_functional = false
+        `,
+        [system_id],
+      );
+      const badPartCount = trackedBadParts.rows[0]?.count || 0;
+      if (badPartCount <= 0) {
+        await client.query("ROLLBACK");
+        return res.status(400).json({
+          error:
+            "Track all estimated CID-damaged parts before moving to Pending MRB.",
+        });
+      }
     }
 
     // RMA validation
@@ -4990,38 +5153,9 @@ router.patch("/:service_tag/rack", authenticateToken, async (req, res) => {
   const stUpper = String(service_tag).trim().toUpperCase();
   const rackUpper = String(rack_service_tag).trim().toUpperCase();
 
-  // SAME checks as POST
-  if (rackUpper.length !== 7) {
-    return res.status(400).json({
-      error: "Rack Service Tag must be exactly 7 characters long",
-    });
-  }
-
-  const fillerTokens = [
-    "UNK",
-    "UNKN",
-    "N/A",
-    "NA",
-    "NONE",
-    "NULL",
-    "(NULL)",
-    "NODATA",
-    "NOINFO",
-    "TBD",
-    "TBA",
-    "N/R",
-    "BLANK",
-    "???",
-    "XXX",
-    "COOLANT",
-  ];
-
-  const rackForMatch = rackUpper.replace(/[\s/.-]/g, "");
-  const hasFiller = fillerTokens.some((tok) => rackForMatch.includes(tok));
-  if (hasFiller) {
-    return res.status(400).json({
-      error: "Please provide a valid Rack Service Tag, not a filler value",
-    });
+  const rackValidationError = validateRackServiceTag(rackUpper);
+  if (rackValidationError) {
+    return res.status(400).json({ error: rackValidationError });
   }
 
   const client = await db.connect();

--- a/website_frontend/src/components/Flowchart.jsx
+++ b/website_frontend/src/components/Flowchart.jsx
@@ -3,12 +3,12 @@ export default function Flowchart({
   locations,
   repairsAllowed,
 }) {
-  const locationsHiddenWhenRepairsDisabled = new Set([3, 4]);
+  const locationsHiddenWhenRepairsDisabled = new Set([4]);
   const locationsHiddenWhenRepairsEnabled = new Set([10]);
-  const arrowsHiddenWhenRepairsDisabled = new Set([3, 4, 6]);
-  const arrowsHiddenWhenRepairsEnabled = new Set([11]);
-  const rectsHiddenWhenRepairsDisabled = new Set([2, 5, 6, 12, 13, 14]);
-  const rectsHiddenWhenRepairsEnabled = new Set([15, 16, 17, 18, 19, 20]);
+  const arrowsHiddenWhenRepairsDisabled = new Set([4]);
+  const arrowsHiddenWhenRepairsEnabled = new Set([]);
+  const rectsHiddenWhenRepairsDisabled = new Set([2, 5, 12]);
+  const rectsHiddenWhenRepairsEnabled = new Set([15, 16, 17, 18, 19, 20, 23]);
 
   const filterByRepairsAllowed = (
     items,
@@ -31,22 +31,24 @@ export default function Flowchart({
       { id: 1, x: 0, y: 150 },
       // In Debug - Wistron
       { id: 2, x: 200, y: 150 },
-      // Pending L11 Logs
-      { id: 3, x: 200, y: 260 },
       // In L10
       { id: 5, x: 400, y: 150 },
       // Sent to L11
-      { id: 9, x: 600, y: 0 },
+      { id: 9, x: 600, y: 100 },
       // RMA VID
-      { id: 6, x: 600, y: 100 },
+      { id: 6, x: 600, y: 200 },
       // RMA PID
-      { id: 8, x: 600, y: 200 },
+      { id: 8, x: 600, y: 0 },
       // RMA CID
       { id: 7, x: 600, y: 300 },
       // Pending Parts
-      { id: 4, x: 200, y: 50 },
+      { id: 4, x: 100, y: 50 },
+      // Pending L11 Logs
+      { id: 3, x: 300, y: 50 },
       // Sent to Dell for Repair
-      { id: 10, x: 200, y: 0 },
+      { id: 10, x: 100, y: 0 },
+      // Pending MRB
+      { id: 11, x: 200, y: 250 },
     ],
     locationsHiddenWhenRepairsDisabled,
     locationsHiddenWhenRepairsEnabled,
@@ -73,97 +75,146 @@ export default function Flowchart({
         stemHeight: 20,
         totalLenth: 40,
         direction: "right",
-        ids: [1, 5],
+        ids: [1],
       },
+      // In L10 to In Debug - Wistron
       {
         id: 2,
-        x: 355,
+        x: 375,
         y: 175,
         stemHeight: 20,
-        totalLenth: 40,
+        totalLenth: 20,
         direction: "right",
         ids: [2],
       },
+
+      // In Debug to Pending Parts
       {
         id: 3,
-        x: 325,
-        y: 215,
+        x: 225,
+        y: repairsAllowed ? 125 : 135,
         stemHeight: 20,
-        totalLenth: 40,
-        direction: "down",
-        ids: [2],
+        totalLenth: repairsAllowed ? 20 : 80,
+        direction: "up",
+        ids: [2, 5],
       },
+      // Pending Parts to In Debug
       {
         id: 4,
         x: 225,
-        y: 145,
+        y: 125,
         stemHeight: 20,
-        totalLenth: 40,
-        direction: "up",
-        ids: [2],
-      },
-      {
-        id: 5,
-        x: 225,
-        y: 250,
-        stemHeight: 20,
-        totalLenth: 45,
-        direction: "up",
-        ids: [3, 5],
-      },
-      {
-        id: 6,
-        x: 325,
-        y: 105,
-        stemHeight: 20,
-        totalLenth: 40,
+        totalLenth: 20,
         direction: "down",
         ids: [4],
       },
+      // MRB to In Debug
+      {
+        id: 5,
+        x: 225,
+        y: 225,
+        stemHeight: 20,
+        totalLenth: 20,
+        direction: "up",
+        ids: [11],
+      },
+      // In Debug to MRB
+      {
+        id: 6,
+        x: 225,
+        y: 225,
+        stemHeight: 20,
+        totalLenth: 20,
+        direction: "down",
+        ids: [2],
+      },
+      //Pending L11 Logs to In Debug
       {
         id: 7,
+        x: 325,
+        y: 125,
+        stemHeight: 20,
+        totalLenth: 20,
+        direction: "down",
+        ids: [3],
+      },
+      // In Debug to Pending L11 Logs
+      {
+        id: 8,
+        x: 325,
+        y: 125,
+        stemHeight: 20,
+        totalLenth: 20,
+        direction: "up",
+        ids: [2],
+      },
+      // Pending L11 Logs to RMA PID
+      {
+        id: 9,
         x: 555,
         y: 25,
         stemHeight: 20,
         totalLenth: 40,
         direction: "right",
-        ids: [5],
+        ids: [2, 5, 3],
       },
+      // Sent to L11
       {
-        id: 8,
+        id: 10,
         x: 555,
         y: 125,
         stemHeight: 20,
         totalLenth: 40,
         direction: "right",
-        ids: [2, 5],
+        ids: [5],
       },
+      // RMA VID
       {
-        id: 9,
+        id: 11,
         x: 555,
         y: 225,
         stemHeight: 20,
         totalLenth: 40,
         direction: "right",
-        ids: [2, 3, 5],
+        ids: [2, 5],
       },
+      // RMA CID
       {
-        id: 10,
+        id: 12,
         x: 555,
         y: 325,
         stemHeight: 20,
         totalLenth: 40,
         direction: "right",
-        ids: [2, 5],
+        ids: [11],
       },
       {
-        id: 11,
-        x: 275,
-        y: 100,
+        id: 13,
+        x: 375,
+        y: 175,
         stemHeight: 20,
-        totalLenth: 45,
-        direction: "up",
-        ids: [2, 5],
+        totalLenth: 20,
+        direction: "left",
+        ids: [5],
+      },
+      // In L10 to Pending MRB
+      {
+        id: 14,
+        x: 465,
+        y: 275,
+        stemHeight: 20,
+        totalLenth: 110,
+        direction: "left",
+        ids: [5],
+      },
+      {
+        id: 15,
+        x: 475,
+        y: 75,
+        stemHeight: 20,
+        totalLenth: 20,
+        direction: "left",
+        ids: [5],
       },
     ],
     arrowsHiddenWhenRepairsDisabled,
@@ -172,68 +223,55 @@ export default function Flowchart({
 
   const rects = filterByRepairsAllowed(
     [
+      // Pending L11 Logs to RMA PID
       {
-        id: 1,
-        x: 325,
+        id: 3,
+        x: 315,
+        y: 15,
+        width: 240,
+        height: 20,
+        direction: "horizontal",
+        ids: [3],
+      },
+      // Horizontal line from Pending L11 Logs to RMA PID
+      {
+        id: 6,
+        x: 315,
+        y: 30,
+        width: 15,
+        height: 20,
+        direction: "vertical",
+        ids: [3],
+      },
+      // In Debug Wistron to RMA
+      {
+        id: 4,
+        x: 315,
         y: 215,
-        width: 67,
+        width: 240,
         height: 20,
         direction: "horizontal",
         ids: [2],
       },
-      {
-        id: 2,
-        x: 355,
-        y: 275,
-        width: 40,
-        height: 20,
-        direction: "horizontal",
-        ids: [3],
-      },
-      {
-        id: 3,
-        x: 390,
-        y: 215,
-        width: 70,
-        height: 20,
-        direction: "horizontal",
-        ids: [2, 3],
-      },
-      {
-        id: 4,
-        x: 490,
-        y: 215,
-        width: 97,
-        height: 20,
-        direction: "horizontal",
-        ids: [2, 3],
-      },
-      {
-        id: 5,
-        x: 175,
-        y: 230,
-        width: 40,
-        height: 20,
-        direction: "horizontal",
-        ids: [5],
-      },
-      {
-        id: 6,
-        x: 215,
-        y: 250,
-        width: 5,
-        height: 20,
-        direction: "vertical",
-        ids: [3],
-      },
+      // Vertical line inbetween RMA PID, Sent to L11 and RMA VID
       {
         id: 7,
         x: 555,
-        y: 134,
-        width: 185,
+        y: 35,
+        width: 180,
         height: 18,
         direction: "vertical",
         ids: [2, 5],
+      },
+      // Vertical line inbetween RMA PID, Sent to L11 and RMA VID
+      {
+        id: 7,
+        x: 465,
+        y: 65,
+        width: 80,
+        height: 18,
+        direction: "vertical",
+        ids: [5],
       },
       {
         id: 8,
@@ -244,6 +282,7 @@ export default function Flowchart({
         direction: "vertical",
         ids: [2],
       },
+      // Small horizonal nub to the right of In L10
       {
         id: 9,
         x: 552,
@@ -253,104 +292,72 @@ export default function Flowchart({
         direction: "horizontal",
         ids: [5],
       },
+      // Pending MRB to RMA CID
       {
-        id: 10,
-        x: 555,
-        y: 25,
-        width: 90,
+        id: 13,
+        x: 215,
+        y: 305,
+        width: 30,
+        height: 20,
+        direction: "vertical",
+        ids: [11],
+      },
+      // Pending MRB to RMA CID
+      {
+        id: 14,
+        x: 220,
+        y: 315,
+        width: 335,
+        height: 20,
+        direction: "horizontal",
+        ids: [11],
+      },
+      {
+        id: 17,
+        x: 350,
+        y: 115,
+        width: 115,
+        height: 20,
+        direction: "horizontal",
+        ids: [5],
+      },
+      {
+        id: 20,
+        x: 235,
+        y: 115,
+        width: 65,
+        height: 20,
+        direction: "horizontal",
+        ids: [5],
+      },
+      //vertical line l10 to pending MRB part 1
+      {
+        id: 21,
+        x: 465,
+        y: 205,
+        width: 5,
+        height: 18,
+        direction: "vertical",
+        ids: [5],
+      },
+      //vertical line l10 to pending MRB part 2
+      {
+        id: 22,
+        x: 465,
+        y: 240,
+        width: 45,
         height: 18,
         direction: "vertical",
         ids: [5],
       },
       {
-        id: 11,
-        x: 465,
-        y: 205,
-        width: 125,
-        height: 20,
-        direction: "vertical",
-        ids: [5],
-      },
-      {
-        id: 12,
-        x: 390,
-        y: 235,
-        width: 60,
-        height: 20,
-        direction: "vertical",
-        ids: [3],
-      },
-      {
-        id: 13,
-        x: 175,
-        y: 230,
-        width: 100,
-        height: 20,
-        direction: "vertical",
-        ids: [5],
-      },
-      {
-        id: 14,
-        x: 175,
-        y: 315,
-        width: 310,
-        height: 20,
-        direction: "horizontal",
-        ids: [5],
-      },
-      {
-        id: 15,
+        id: 23,
         x: 215,
-        y: 315,
-        width: 270,
-        height: 20,
-        direction: "horizontal",
-        ids: [5],
-      },
-      {
-        id: 16,
-        x: 215,
-        y: 230,
-        width: 100,
-        height: 20,
-        direction: "vertical",
-        ids: [5],
-      },
-      {
-        id: 17,
-        x: 285,
-        y: 100,
-        width: 200,
-        height: 20,
-        direction: "horizontal",
-        ids: [5],
-      },
-      {
-        id: 18,
-        x: 265,
-        y: 100,
-        width: 20,
-        height: 20,
-        direction: "horizontal",
-        ids: [2, 5],
-      },
-      {
-        id: 19,
-        x: 265,
-        y: 120,
-        width: 25,
+        y: 135,
+        width: 10,
         height: 20,
         direction: "vertical",
         ids: [2],
-      },
-      {
-        id: 20,
-        x: 465,
-        y: 120,
-        width: 25,
-        height: 20,
-        direction: "vertical",
-        ids: [5],
       },
     ],
     rectsHiddenWhenRepairsDisabled,
@@ -417,6 +424,100 @@ export default function Flowchart({
         </g>
       ))}
 
+      {/* Render arrows */}
+      {arrows.map((arrow, idx) => {
+        const stemThickness = arrow.stemHeight ?? 20;
+        const totalLength = arrow.totalLenth ?? 40;
+        const direction = arrow.direction ?? "right";
+
+        const headLengthFactor = 0.8;
+        const headHeightFactor = 1.8;
+        const headLength = stemThickness * headLengthFactor;
+        const headHeight = stemThickness * headHeightFactor;
+        const stemLength = Math.max(0, totalLength - headLength);
+
+        const cx = arrow.x;
+        const cy = arrow.y;
+
+        const isActive = arrow.ids?.includes(currentLocation_id);
+        const fill = isActive ? "#bfdbfe" : "#9ca3af";
+
+        let stemX = cx;
+        let stemY = cy;
+        let stemWidth = 0;
+        let stemHeight = 0;
+        let points = "";
+
+        if (direction === "right") {
+          stemX = cx;
+          stemY = cy - stemThickness / 2;
+          stemWidth = stemLength;
+          stemHeight = stemThickness;
+
+          const headBaseX = cx + stemLength;
+
+          points = `
+            ${headBaseX},${cy - headHeight / 2}
+            ${headBaseX + headLength},${cy}
+            ${headBaseX},${cy + headHeight / 2}
+          `;
+        } else if (direction === "left") {
+          stemX = cx - stemLength;
+          stemY = cy - stemThickness / 2;
+          stemWidth = stemLength;
+          stemHeight = stemThickness;
+
+          const headBaseX = cx - stemLength;
+
+          points = `
+            ${headBaseX},${cy - headHeight / 2}
+            ${headBaseX - headLength},${cy}
+            ${headBaseX},${cy + headHeight / 2}
+          `;
+        } else if (direction === "down") {
+          stemX = cx - stemThickness / 2;
+          stemY = cy;
+          stemWidth = stemThickness;
+          stemHeight = stemLength;
+
+          const headBaseY = cy + stemLength;
+
+          points = `
+            ${cx - headHeight / 2},${headBaseY}
+            ${cx},${headBaseY + headLength}
+            ${cx + headHeight / 2},${headBaseY}
+          `;
+        } else if (direction === "up") {
+          stemX = cx - stemThickness / 2;
+          stemY = cy - stemLength;
+          stemWidth = stemThickness;
+          stemHeight = stemLength;
+
+          const headBaseY = cy - stemLength;
+
+          points = `
+            ${cx - headHeight / 2},${headBaseY}
+            ${cx},${headBaseY - headLength}
+            ${cx + headHeight / 2},${headBaseY}
+          `;
+        }
+
+        return (
+          <g key={idx}>
+            {stemWidth > 0 && stemHeight > 0 && (
+              <rect
+                x={stemX}
+                y={stemY}
+                width={stemWidth}
+                height={stemHeight}
+                fill={fill}
+              />
+            )}
+            <polygon points={points} fill={fill} />
+          </g>
+        );
+      })}
+
       {/* Render rects */}
       {rects.map((rect, idx) => {
         const baseX = rect.x;
@@ -441,98 +542,6 @@ export default function Flowchart({
             height={h}
             fill={fill}
           />
-        );
-      })}
-
-      {/* Render arrows */}
-      {arrows.map((arrow, idx) => {
-        const stemThickness = arrow.stemHeight ?? 20;
-        const totalLength = arrow.totalLenth ?? 40;
-        const direction = arrow.direction ?? "right";
-
-        const headLength = totalLength * 0.4;
-        const stemLength = totalLength - headLength;
-
-        const headHeightFactor = 1.8;
-        const headHeight = stemThickness * headHeightFactor;
-
-        const cx = arrow.x;
-        const cy = arrow.y;
-
-        const isActive = arrow.ids?.includes(currentLocation_id);
-        const fill = isActive ? "#bfdbfe" : "#9ca3af";
-
-        let stemX = cx;
-        let stemY = cy;
-        let stemWidth = 0;
-        let stemHeight = 0;
-        let points = "";
-
-        if (direction === "right") {
-          stemX = cx;
-          stemY = cy - stemThickness / 2;
-          stemWidth = stemLength + 1;
-          stemHeight = stemThickness;
-
-          const headBaseX = cx + stemLength;
-
-          points = `
-            ${headBaseX},${cy - headHeight / 2}
-            ${headBaseX + headLength},${cy}
-            ${headBaseX},${cy + headHeight / 2}
-          `;
-        } else if (direction === "left") {
-          stemX = cx - stemLength - 1;
-          stemY = cy - stemThickness / 2;
-          stemWidth = stemLength + 1;
-          stemHeight = stemThickness;
-
-          const headBaseX = cx - stemLength;
-
-          points = `
-            ${headBaseX},${cy - headHeight / 2}
-            ${headBaseX - headLength},${cy}
-            ${headBaseX},${cy + headHeight / 2}
-          `;
-        } else if (direction === "down") {
-          stemX = cx - stemThickness / 2;
-          stemY = cy;
-          stemWidth = stemThickness;
-          stemHeight = stemLength + 1;
-
-          const headBaseY = cy + stemLength;
-
-          points = `
-            ${cx - headHeight / 2},${headBaseY}
-            ${cx},${headBaseY + headLength}
-            ${cx + headHeight / 2},${headBaseY}
-          `;
-        } else if (direction === "up") {
-          stemX = cx - stemThickness / 2;
-          stemY = cy - stemLength - 1;
-          stemWidth = stemThickness;
-          stemHeight = stemLength + 1;
-
-          const headBaseY = cy - stemLength;
-
-          points = `
-            ${cx - headHeight / 2},${headBaseY}
-            ${cx},${headBaseY - headLength}
-            ${cx + headHeight / 2},${headBaseY}
-          `;
-        }
-
-        return (
-          <g key={idx}>
-            <rect
-              x={stemX}
-              y={stemY}
-              width={stemWidth}
-              height={stemHeight}
-              fill={fill}
-            />
-            <polygon points={points} fill={fill} />
-          </g>
         );
       })}
     </svg>

--- a/website_frontend/src/components/SystemL10PassLabel.jsx
+++ b/website_frontend/src/components/SystemL10PassLabel.jsx
@@ -14,6 +14,12 @@ const LABEL_WIDTH = 144;
 const LABEL_HEIGHT = 72;
 const SCALE = 1;
 const S = (n) => Math.round(n * SCALE * 100) / 100;
+const formatPrintDate = () =>
+  new Intl.DateTimeFormat("en-US", {
+    month: "2-digit",
+    day: "2-digit",
+    year: "numeric",
+  }).format(new Date());
 
 const styles = StyleSheet.create({
   page: {
@@ -96,47 +102,61 @@ const styles = StyleSheet.create({
     fontFamily: "Helvetica",
     lineHeight: 1.2,
   },
+  footer_text: {
+    position: "absolute",
+    left: S(7),
+    bottom: S(2),
+    width: S(120),
+    fontSize: S(6),
+    fontFamily: "Helvetica",
+    color: "#374151",
+    lineHeight: 1.1,
+  },
 });
 
-const SystemPDFLabel = ({ systems }) => (
-  <Document>
-    {systems.map((system, index) => (
-      <Page
-        key={index}
-        size={{ width: LABEL_WIDTH, height: LABEL_HEIGHT }}
-        style={styles.page}
-      >
-        <View style={styles.canvas}>
-          <View style={styles.label}>
-            {/* ✅ Vector checkmark */}
-            <View style={styles.checkWrap}>
-              <Svg viewBox="0 0 24 24" width="100%" height="100%">
-                <Path
-                  d="M20 6L9 17l-5-5"
-                  stroke="#111827"
-                  strokeWidth={2}
-                  fill="none"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-              </Svg>
-            </View>
+const SystemPDFLabel = ({ systems }) => {
+  const printDate = formatPrintDate();
+  return (
+    <Document>
+      {systems.map((system, index) => (
+        <Page
+          key={index}
+          size={{ width: LABEL_WIDTH, height: LABEL_HEIGHT }}
+          style={styles.page}
+        >
+          <View style={styles.canvas}>
+            <View style={styles.label}>
+              {/* ✅ Vector checkmark */}
+              <View style={styles.checkWrap}>
+                <Svg viewBox="0 0 24 24" width="100%" height="100%">
+                  <Path
+                    d="M20 6L9 17l-5-5"
+                    stroke="#111827"
+                    strokeWidth={2}
+                    fill="none"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  />
+                </Svg>
+              </View>
 
-            <Text style={styles.text}>{system.service_tag}</Text>
-            <View style={styles.wistron_wrap}>
-              <Text style={styles.issue_text}>Passed L10</Text>
+              <Text style={styles.text}>{system.service_tag}</Text>
+              <View style={styles.wistron_wrap}>
+                <Text style={styles.issue_text}>Passed L10</Text>
+              </View>
+              <Text style={styles.dpn_text}>
+                {system.dpn} - Config {system.config}
+              </Text>
+              <Text style={styles.dell_customer_text}>
+                {system.dell_customer}
+              </Text>
+              <Text style={styles.footer_text}>Printed: {printDate}</Text>
             </View>
-            <Text style={styles.dpn_text}>
-              {system.dpn} - Config {system.config}
-            </Text>
-            <Text style={styles.dell_customer_text}>
-              {system.dell_customer}
-            </Text>
           </View>
-        </View>
-      </Page>
-    ))}
-  </Document>
-);
+        </Page>
+      ))}
+    </Document>
+  );
+};
 
 export default SystemPDFLabel;

--- a/website_frontend/src/components/SystemPDFLabel.jsx
+++ b/website_frontend/src/components/SystemPDFLabel.jsx
@@ -13,6 +13,12 @@ const LABEL_WIDTH = 144;
 const LABEL_HEIGHT = 72;
 const SCALE = 0.9;
 const S = (n) => Math.round(n * SCALE * 100) / 100; // neat rounding
+const formatPrintDate = () =>
+  new Intl.DateTimeFormat("en-US", {
+    month: "2-digit",
+    day: "2-digit",
+    year: "numeric",
+  }).format(new Date());
 
 const styles = StyleSheet.create({
   // Make the page act like a centering canvas
@@ -99,9 +105,20 @@ const styles = StyleSheet.create({
     fontFamily: "Helvetica",
     lineHeight: 1.2,
   },
+  footer_text: {
+    position: "absolute",
+    left: S(7),
+    bottom: S(2),
+    width: S(120),
+    fontSize: S(6),
+    fontFamily: "Helvetica",
+    color: "#374151",
+    lineHeight: 1.1,
+  },
 });
 
 const SystemPDFLabel = ({ systems }) => {
+  const printDate = formatPrintDate();
   return (
     <Document>
       {systems.map((system, index) => {
@@ -127,6 +144,8 @@ const SystemPDFLabel = ({ systems }) => {
                 <Text style={styles.dell_customer_text}>
                   {system.dell_customer}
                 </Text>
+
+                <Text style={styles.footer_text}>Printed: {printDate}</Text>
 
                 <Image style={styles.qr} src={qrDataUrl} />
               </View>

--- a/website_frontend/src/components/SystemPendingPartsLabel.jsx
+++ b/website_frontend/src/components/SystemPendingPartsLabel.jsx
@@ -4,6 +4,12 @@ import { Document, Page, View, Text, StyleSheet } from "@react-pdf/renderer";
 
 const LABEL_WIDTH = 144;
 const LABEL_HEIGHT = 72;
+const formatPrintDate = () =>
+  new Intl.DateTimeFormat("en-US", {
+    month: "2-digit",
+    day: "2-digit",
+    year: "numeric",
+  }).format(new Date());
 
 const styles = StyleSheet.create({
   page: {
@@ -44,9 +50,17 @@ const styles = StyleSheet.create({
     textAlign: "center",
     marginTop: 8,
   },
+  footer: {
+    marginTop: "auto",
+    fontFamily: "Helvetica",
+    fontSize: 6,
+    color: "#374151",
+    textAlign: "left",
+  },
 });
 
-const SystemPendingPartsLabel = ({ parts = [] }) => {
+const SystemPendingPartsLabel = ({ parts = [], title = "Pending Parts" }) => {
+  const printDate = formatPrintDate();
   const names = (parts || [])
     .map((p) => (p || "").toString().trim())
     .filter(Boolean);
@@ -55,11 +69,11 @@ const SystemPendingPartsLabel = ({ parts = [] }) => {
     <Document>
       <Page
         size={{ width: LABEL_WIDTH, height: LABEL_HEIGHT }}
-        style={styles.page}
+          style={styles.page}
       >
         <View style={styles.canvas}>
           <View style={styles.card}>
-            <Text style={styles.title}>Pending Parts</Text>
+            <Text style={styles.title}>{title}</Text>
             {names.length ? (
               names.map((name, i) => (
                 <Text key={i} style={styles.item}>
@@ -69,6 +83,7 @@ const SystemPendingPartsLabel = ({ parts = [] }) => {
             ) : (
               <Text style={styles.empty}>No parts listed</Text>
             )}
+            <Text style={styles.footer}>Printed: {printDate}</Text>
           </View>
         </View>
       </Page>

--- a/website_frontend/src/components/SystemRMALabel.jsx
+++ b/website_frontend/src/components/SystemRMALabel.jsx
@@ -14,6 +14,12 @@ import { generateQRPNG } from "../utils/generateQR";
 
 const LABEL_WIDTH = 144;
 const LABEL_HEIGHT = 72;
+const formatPrintDate = () =>
+  new Intl.DateTimeFormat("en-US", {
+    month: "2-digit",
+    day: "2-digit",
+    year: "numeric",
+  }).format(new Date());
 
 const getDpnForLabel = (system = {}) => {
   const explicit = String(system.dpn || system.dpn_name || "").trim();
@@ -84,6 +90,16 @@ const styles = StyleSheet.create({
     position: "absolute",
     right: 10,
     top: 8,
+  },
+  footer_text: {
+    position: "absolute",
+    left: 7,
+    bottom: 3,
+    width: 80,
+    fontSize: 6,
+    fontFamily: "Helvetica",
+    color: "#374151",
+    lineHeight: 1.1,
   },
 });
 
@@ -236,6 +252,7 @@ function ShapeBadge({ shape, palletNumber, size = 18 }) {
 }
 
 const SystemRMALabel = ({ systems }) => {
+  const printDate = formatPrintDate();
   return (
     <Document>
       {systems.map((system, index) => {
@@ -265,6 +282,7 @@ const SystemRMALabel = ({ systems }) => {
               <Text style={styles.dpn_text}>{dpnConfigText}</Text>
 
               <Text style={styles.factory_text}>{system.dell_customer}</Text>
+              <Text style={styles.footer_text}>Printed: {printDate}</Text>
             </View>
           </Page>
         );

--- a/website_frontend/src/helpers/NextAllowedLocations.jsx
+++ b/website_frontend/src/helpers/NextAllowedLocations.jsx
@@ -17,22 +17,27 @@ export function allowedNextLocations(
               "In Debug - Wistron",
               "RMA VID",
               "RMA PID",
-              "RMA CID",
+              "Pending MRB",
             ].includes(l.name),
           )
         : locations.filter((l) =>
             [
               "In L10",
               "In Debug - Wistron",
+              "Pending L11 Logs",
               "RMA VID",
               "RMA PID",
-              "RMA CID",
+              "Pending MRB",
               "Sent for Dell Repair",
             ].includes(l.name),
           );
     case "Pending Parts":
       return locations.filter((l) =>
         ["Pending Parts", "In Debug - Wistron"].includes(l.name),
+      );
+    case "Pending MRB":
+      return locations.filter((l) =>
+        ["Pending MRB", "In Debug - Wistron", "RMA CID"].includes(l.name),
       );
     case "Pending L11 Logs":
       return locations.filter((l) =>
@@ -48,18 +53,20 @@ export function allowedNextLocations(
         ? locations.filter((l) =>
             [
               "In Debug - Wistron",
+              "Pending MRB",
+              "Pending L11 Logs",
               "RMA VID",
               "RMA PID",
-              "RMA CID",
               "Sent to L11",
             ].includes(l.name),
           )
         : locations.filter((l) =>
             [
               "In Debug - Wistron",
+              "Pending MRB",
+              "Pending L11 Logs",
               "RMA VID",
               "RMA PID",
-              "RMA CID",
               "Sent to L11",
               "Sent for Dell Repair",
             ].includes(l.name),

--- a/website_frontend/src/hooks/useApi.jsx
+++ b/website_frontend/src/hooks/useApi.jsx
@@ -218,6 +218,18 @@ function useApi() {
         l11_log_reconciliation_mode: !!l11_log_reconciliation_mode,
       }),
     });
+  const getPendingL11MoveRule = () => fetchJSON(`/server/pending_l11_move_rule`);
+  const updatePendingL11MoveRule = (pending_l11_move_rule) =>
+    fetchJSON(`/server/pending_l11_move_rule`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        pending_l11_move_rule: {
+          enabled: !!pending_l11_move_rule?.enabled,
+          minutes: pending_l11_move_rule?.minutes,
+        },
+      }),
+    });
 
   const createSystem = (payload) =>
     fetchJSON("/systems", {
@@ -980,6 +992,8 @@ function useApi() {
     updateRepairsAllowed,
     getL11LogReconciliationMode,
     updateL11LogReconciliationMode,
+    getPendingL11MoveRule,
+    updatePendingL11MoveRule,
     getSnapshot,
     updateSystemPPID,
     updateSystemDOA,

--- a/website_frontend/src/hooks/useConfirm.jsx
+++ b/website_frontend/src/hooks/useConfirm.jsx
@@ -62,7 +62,9 @@ export default function useConfirm() {
           <h2 className="text-lg sm:text-xl font-semibold text-gray-800">
             {config.title}
           </h2>
-          <p className="text-gray-700 text-sm sm:text-base">{config.message}</p>
+          <p className="whitespace-pre-line text-gray-700 text-sm sm:text-base">
+            {config.message}
+          </p>
           <div className="flex flex-wrap justify-end gap-2">
             <button
               type="button"

--- a/website_frontend/src/hooks/usePrintConfirmPendingParts.jsx
+++ b/website_frontend/src/hooks/usePrintConfirmPendingParts.jsx
@@ -3,12 +3,14 @@ import useBodyScrollLock from "./useBodyScrollLock.jsx";
 
 export default function usePrintConfirmPendingParts() {
   const [isOpen, setIsOpen] = useState(false);
+  const [labelName, setLabelName] = useState("Pending Parts");
   const resolveRef = useRef(null);
   const resolvedRef = useRef(false);
   useBodyScrollLock(isOpen);
 
-  const confirmPrintPendingParts = () =>
+  const confirmPrintPendingParts = (nextLabelName = "Pending Parts") =>
     new Promise((resolve) => {
+      setLabelName(nextLabelName);
       setIsOpen(true);
       resolveRef.current = resolve;
       resolvedRef.current = false;
@@ -71,7 +73,7 @@ export default function usePrintConfirmPendingParts() {
             Choose Label Type
           </h2>
           <p className="text-sm text-gray-600">
-            This system is pending parts. Which label would you like to print?
+            {`This system is ${labelName.toLowerCase()}. Which label would you like to print?`}
           </p>
 
           <div className="flex flex-col sm:flex-row gap-2 sm:justify-between mt-4">
@@ -86,7 +88,7 @@ export default function usePrintConfirmPendingParts() {
               className="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700 text-sm"
               onClick={() => handleChoice("parts")}
             >
-              Pending Parts Label
+              {labelName} Label
             </button>
           </div>
         </div>

--- a/website_frontend/src/pages/AdminPage.jsx
+++ b/website_frontend/src/pages/AdminPage.jsx
@@ -44,6 +44,8 @@ function AdminPage() {
     updateRepairsAllowed,
     getL11LogReconciliationMode,
     updateL11LogReconciliationMode,
+    getPendingL11MoveRule,
+    updatePendingL11MoveRule,
   } = useApi();
   const [users, setUsers] = useState([]);
   const [baselineUsers, setBaselineUsers] = useState([]); // snapshot to diff from
@@ -106,6 +108,14 @@ function AdminPage() {
   const [l11LogReconciliationModeLoading, setL11LogReconciliationModeLoading] =
     useState(false);
   const [l11LogReconciliationModeSaving, setL11LogReconciliationModeSaving] =
+    useState(false);
+  const [pendingL11MoveRule, setPendingL11MoveRule] = useState({
+    enabled: false,
+    minutes: 30,
+  });
+  const [pendingL11MoveRuleLoading, setPendingL11MoveRuleLoading] =
+    useState(false);
+  const [pendingL11MoveRuleSaving, setPendingL11MoveRuleSaving] =
     useState(false);
 
   const normalizeDpns = (list = []) =>
@@ -247,6 +257,29 @@ function AdminPage() {
         console.error("Failed to load repairs_allowed:", e);
       } finally {
         if (alive) setRepairsAllowedLoading(false);
+      }
+    })();
+    return () => {
+      alive = false;
+    };
+  }, []);
+
+  useEffect(() => {
+    let alive = true;
+    (async () => {
+      try {
+        setPendingL11MoveRuleLoading(true);
+        const res = await getPendingL11MoveRule();
+        if (!alive) return;
+        setPendingL11MoveRule({
+          enabled: !!res?.pending_l11_move_rule?.enabled,
+          minutes: Number.parseInt(res?.pending_l11_move_rule?.minutes, 10) || 30,
+        });
+      } catch (e) {
+        if (!alive) return;
+        console.error("Failed to load pending_l11_move_rule:", e);
+      } finally {
+        if (alive) setPendingL11MoveRuleLoading(false);
       }
     })();
     return () => {
@@ -1457,6 +1490,104 @@ function AdminPage() {
     }
   };
 
+  const handlePendingL11MoveRuleToggle = async () => {
+    const nextValue = !pendingL11MoveRule.enabled;
+    const confirmed = await confirm({
+      title: nextValue
+        ? "Enable Pending L11 Delay"
+        : "Disable Pending L11 Delay",
+      message: nextValue
+        ? "Require a wait period after a unit returns to Received before it can move into Pending L11 Logs?"
+        : "Remove the wait-period restriction for moves into Pending L11 Logs?",
+      confirmText: nextValue ? "Enable" : "Disable",
+      cancelText: "Cancel",
+      confirmClass: nextValue
+        ? "bg-indigo-600 text-white hover:bg-indigo-700"
+        : "bg-gray-700 text-white hover:bg-gray-800",
+      cancelClass: "bg-gray-200 text-gray-700 hover:bg-gray-300",
+    });
+    if (!confirmed) return;
+
+    try {
+      setPendingL11MoveRuleSaving(true);
+      const res = await updatePendingL11MoveRule({
+        ...pendingL11MoveRule,
+        enabled: nextValue,
+      });
+      const nextRule = res?.pending_l11_move_rule || {
+        enabled: nextValue,
+        minutes: pendingL11MoveRule.minutes,
+      };
+      setPendingL11MoveRule({
+        enabled: !!nextRule.enabled,
+        minutes: Number.parseInt(nextRule.minutes, 10) || 30,
+      });
+      showToast(
+        `Pending L11 delay ${nextRule.enabled ? "enabled" : "disabled"}`,
+        "success",
+        2200,
+        "bottom-right",
+      );
+    } catch (e) {
+      showToast(
+        e?.body?.error ||
+          e?.message ||
+          "Failed to update Pending L11 delay setting",
+        "error",
+        3200,
+        "bottom-right",
+      );
+    } finally {
+      setPendingL11MoveRuleSaving(false);
+    }
+  };
+
+  const handlePendingL11MoveRuleMinutesSave = async () => {
+    const parsedMinutes = Number.parseInt(pendingL11MoveRule.minutes, 10);
+    if (!Number.isInteger(parsedMinutes) || parsedMinutes <= 0) {
+      showToast(
+        "Pending L11 delay minutes must be a positive whole number.",
+        "error",
+        3200,
+        "bottom-right",
+      );
+      return;
+    }
+
+    try {
+      setPendingL11MoveRuleSaving(true);
+      const res = await updatePendingL11MoveRule({
+        ...pendingL11MoveRule,
+        minutes: parsedMinutes,
+      });
+      const nextRule = res?.pending_l11_move_rule || {
+        enabled: pendingL11MoveRule.enabled,
+        minutes: parsedMinutes,
+      };
+      setPendingL11MoveRule({
+        enabled: !!nextRule.enabled,
+        minutes: Number.parseInt(nextRule.minutes, 10) || 30,
+      });
+      showToast(
+        "Pending L11 delay updated",
+        "success",
+        2200,
+        "bottom-right",
+      );
+    } catch (e) {
+      showToast(
+        e?.body?.error ||
+          e?.message ||
+          "Failed to update Pending L11 delay minutes",
+        "error",
+        3200,
+        "bottom-right",
+      );
+    } finally {
+      setPendingL11MoveRuleSaving(false);
+    }
+  };
+
   return (
     <>
       <Toast />
@@ -1544,6 +1675,77 @@ function AdminPage() {
                   ? "Disable Reconciliation"
                   : "Enable Reconciliation"}
             </button>
+          </div>
+        </section>
+
+        <section className="rounded-2xl border border-indigo-200 bg-indigo-50/70 p-4">
+          <div className="flex flex-col gap-4">
+            <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+              <div>
+                <div className="text-sm font-semibold text-gray-900">
+                  Pending L11 Move Delay
+                </div>
+                <p className="mt-1 text-sm text-gray-700">
+                  Prevents moves into Pending L11 Logs for a configurable amount
+                  of time after a unit is moved back into Received.
+                  <br />
+                  Gives pending MFT log downloads time to complete.
+                </p>
+                <p className="mt-2 text-xs font-medium uppercase tracking-wide text-indigo-700">
+                  {pendingL11MoveRuleLoading
+                    ? "Loading current state..."
+                    : pendingL11MoveRule.enabled
+                      ? `Enabled for ${pendingL11MoveRule.minutes} minute(s)`
+                      : "Currently disabled"}
+                </p>
+              </div>
+
+              <button
+                type="button"
+                disabled={pendingL11MoveRuleLoading || pendingL11MoveRuleSaving}
+                onClick={handlePendingL11MoveRuleToggle}
+                className={`inline-flex items-center justify-center rounded-xl px-4 py-2 text-sm font-semibold text-white shadow transition disabled:opacity-50 ${
+                  pendingL11MoveRule.enabled
+                    ? "bg-gray-700 hover:bg-gray-800"
+                    : "bg-indigo-600 hover:bg-indigo-700"
+                }`}
+              >
+                {pendingL11MoveRuleSaving
+                  ? "Saving..."
+                  : pendingL11MoveRule.enabled
+                    ? "Disable Delay"
+                    : "Enable Delay"}
+              </button>
+            </div>
+
+            <div className="flex flex-col gap-3 sm:flex-row sm:items-end">
+              <label className="flex max-w-xs flex-col gap-1 text-sm text-gray-700">
+                <span className="font-medium text-gray-900">Wait time (minutes)</span>
+                <input
+                  type="number"
+                  min="1"
+                  step="1"
+                  disabled={pendingL11MoveRuleLoading || pendingL11MoveRuleSaving}
+                  value={pendingL11MoveRule.minutes}
+                  onChange={(e) =>
+                    setPendingL11MoveRule((prev) => ({
+                      ...prev,
+                      minutes: e.target.value,
+                    }))
+                  }
+                  className="rounded-xl border border-indigo-200 bg-white px-3 py-2 text-sm shadow-sm focus:border-indigo-400 focus:outline-none focus:ring-2 focus:ring-indigo-200 disabled:opacity-60"
+                />
+              </label>
+
+              <button
+                type="button"
+                disabled={pendingL11MoveRuleLoading || pendingL11MoveRuleSaving}
+                onClick={handlePendingL11MoveRuleMinutesSave}
+                className="inline-flex items-center justify-center rounded-xl bg-indigo-600 px-4 py-2 text-sm font-semibold text-white shadow transition hover:bg-indigo-700 disabled:opacity-50"
+              >
+                {pendingL11MoveRuleSaving ? "Saving..." : "Save Minutes"}
+              </button>
+            </div>
           </div>
         </section>
 

--- a/website_frontend/src/pages/PartsPage.jsx
+++ b/website_frontend/src/pages/PartsPage.jsx
@@ -13,10 +13,13 @@ const buildGroupedPartOptions = (parts = []) => {
   const byCat = new Map();
   parts.forEach((p) => {
     const cat = p.category_name || "Uncategorized";
+    const dpn = (p.dpn || "").trim();
     if (!byCat.has(cat)) byCat.set(cat, []);
     byCat.get(cat).push({
       value: p.id,
-      label: p.name,
+      label: dpn ? `${p.name} [${dpn}]` : p.name,
+      rawLabel: p.name,
+      dpn,
       category_name: cat,
       part_category_id: p.part_category_id,
     });
@@ -33,12 +36,19 @@ const filterPartOption = (option, rawInput) => {
   if (!rawInput) return true;
   const term = rawInput.toLowerCase();
   const label = (option?.label || "").toLowerCase();
+  const rawLabel = (option?.data?.rawLabel ?? option?.rawLabel ?? "").toLowerCase();
   const cat = (
     option?.data?.category_name ??
     option?.category_name ??
     ""
   ).toLowerCase();
-  return label.includes(term) || cat.includes(term);
+  const dpn = (option?.data?.dpn ?? option?.dpn ?? "").toLowerCase();
+  return (
+    label.includes(term) ||
+    rawLabel.includes(term) ||
+    cat.includes(term) ||
+    dpn.includes(term)
+  );
 };
 
 const PartOption = (props) => {

--- a/website_frontend/src/pages/SystemPage.jsx
+++ b/website_frontend/src/pages/SystemPage.jsx
@@ -108,6 +108,12 @@ function formatL11ScanToastMessage({ status, stdout = "" }) {
 
 function SystemPage() {
   const FRONTEND_URL = import.meta.env.VITE_URL;
+  const PENDING_PARTS_NAME = "Pending Parts";
+  const PENDING_MRB_NAME = "Pending MRB";
+  const PENDING_MRB_REQUIRED_BAD_ERROR =
+    "Track all estimated CID-damaged parts before moving to Pending MRB.";
+  const PENDING_MRB_GOOD_PARTS_ERROR =
+    "Return/remove all good parts before moving to Pending MRB.";
 
   const { serviceTag } = useParams();
 
@@ -135,6 +141,10 @@ function SystemPage() {
   const [repairsAllowed, setRepairsAllowed] = useState(null);
   const [l11LogReconciliationMode, setL11LogReconciliationMode] =
     useState(false);
+  const [pendingL11MoveRule, setPendingL11MoveRule] = useState({
+    enabled: false,
+    minutes: 30,
+  });
   const [showPhotoMenu, setShowPhotoMenu] = useState(false);
   const [showL11Menu, setShowL11Menu] = useState(false);
   const [showPhoneQr, setShowPhoneQr] = useState(false);
@@ -244,6 +254,19 @@ function SystemPage() {
       return Number.isFinite(photoMs) && photoMs > latestReceivedMs;
     });
   }, [latestReceivedAt, photos]);
+  const pendingL11MoveRuleRemainingMinutes = useMemo(() => {
+    if (!pendingL11MoveRule.enabled) return 0;
+    const latestReceivedMs = Date.parse(String(latestReceivedAt || ""));
+    if (!Number.isFinite(latestReceivedMs)) return 0;
+
+    const requiredMs = Number(pendingL11MoveRule.minutes || 0) * 60 * 1000;
+    if (!Number.isFinite(requiredMs) || requiredMs <= 0) return 0;
+
+    return Math.max(
+      0,
+      Math.ceil((requiredMs - (Date.now() - latestReceivedMs)) / 60000),
+    );
+  }, [latestReceivedAt, pendingL11MoveRule]);
   const hasSystemFolderEvidence =
     Number(system?.l10_logs_total_size_bytes || 0) > 0;
 
@@ -311,6 +334,7 @@ function SystemPage() {
     exportSystemUnitData,
     getRepairsAllowed,
     getL11LogReconciliationMode,
+    getPendingL11MoveRule,
   } = useApi();
 
   const { confirm, ConfirmDialog } = useConfirm();
@@ -569,11 +593,48 @@ function SystemPage() {
     return m;
   }, [flatPartOptions]);
 
+  const isInDebugWistron = system?.location === "In Debug - Wistron";
+  const isInPendingParts = system?.location === PENDING_PARTS_NAME;
+  const isInPendingMrb = system?.location === PENDING_MRB_NAME;
+  const toLocationName =
+    locations.find((l) => l.id === toLocationId)?.name || "";
+  const pendingTrackingPartOptions = useMemo(
+    () =>
+      toLocationName === PENDING_MRB_NAME ? partOptions : pendingPartOptions,
+    [partOptions, pendingPartOptions, toLocationName],
+  );
+  const pendingPartsLocationId =
+    locations.find((l) => l.name === PENDING_PARTS_NAME)?.id ?? 4;
+  const pendingMrbLocationId =
+    locations.find((l) => l.name === PENDING_MRB_NAME)?.id ?? null;
+  const isPendingTrackingDestination =
+    toLocationName === PENDING_PARTS_NAME ||
+    toLocationName === PENDING_MRB_NAME;
+  const pendingTrackingActionLabel =
+    toLocationName === PENDING_MRB_NAME
+      ? "+ Add Defective Part"
+      : "+ Add Pending Part";
+  const pendingTrackingEmptyLabel =
+    toLocationName === PENDING_MRB_NAME
+      ? "No defective parts queued. Click “Add Defective Part” to begin."
+      : "No pending parts to be added. Click “Add Pending Part” to begin.";
+  const pendingTrackingSectionLabel =
+    toLocationName === PENDING_MRB_NAME
+      ? "Defective parts to track in the system"
+      : "Pending Parts the unit will need";
+  const isInL10 = system?.location === "In L10";
+  const toIsDebugOrL10 =
+    toLocationName === "In Debug - Wistron" || toLocationName === "In L10";
+  const isInReceived = system?.location === "Received";
+
   // Keep “Mark as Working” selections when flipping between destination buttons.
-  // Only clear the temp “pending bad parts” blocks when we’re NOT in the Pending Parts flow.
+  // Only clear the temp pending-material blocks when we’re NOT in a pending-material flow.
   useEffect(() => {
     const inPendingFlow =
-      toLocationId === 4 || system?.location === "Pending Parts";
+      toLocationName === PENDING_PARTS_NAME ||
+      toLocationName === PENDING_MRB_NAME ||
+      system?.location === PENDING_PARTS_NAME ||
+      system?.location === PENDING_MRB_NAME;
 
     if (!inPendingFlow) {
       setPendingBlocks([]);
@@ -606,7 +667,10 @@ function SystemPage() {
 
   useEffect(() => {
     const showPending =
-      toLocationId === 4 || system?.location === "Pending Parts";
+      toLocationName === PENDING_PARTS_NAME ||
+      toLocationName === PENDING_MRB_NAME ||
+      system?.location === PENDING_PARTS_NAME ||
+      system?.location === PENDING_MRB_NAME;
     if (!showPending) return;
     let alive = true;
     (async () => {
@@ -634,26 +698,20 @@ function SystemPage() {
       alive = false;
     };
   }, [toLocationId, system?.location]);
-  const isInDebugWistron = system?.location === "In Debug - Wistron";
-  const isInPendingParts = system?.location === "Pending Parts";
-  const toLocationName =
-    locations.find((l) => l.id === toLocationId)?.name || "";
-  const isInL10 = system?.location === "In L10";
-  const toIsDebugOrL10 =
-    toLocationName === "In Debug - Wistron" || toLocationName === "In L10";
-  const isInReceived = system?.location === "Received";
 
   const canAddGoodParts =
     (isInDebugWistron &&
-      toLocationId !== 4 &&
+      !isPendingTrackingDestination &&
       !isInPendingParts &&
+      !isInPendingMrb &&
       !isInL10 &&
       toLocationId != 6 &&
       toLocationId != 7 &&
       toLocationId != 8) || // current location is Debug, but not sending to Pending
     (toIsDebugOrL10 &&
-      toLocationId !== 4 &&
+      !isPendingTrackingDestination &&
       !isInPendingParts &&
+      !isInPendingMrb &&
       !isInL10 &&
       !isInReceived); // explicitly moving to Debug/L10, not Pending
 
@@ -666,12 +724,79 @@ function SystemPage() {
     });
   };
 
+  const confirmMarkAsWorking = async () =>
+    confirm({
+      title: "Mark as Working?",
+      message:
+        "Mark this as working only if the original part is good.\n\nDo not use this if the part is being replaced and its PPID is not in the 'Replacement PPID' list. If this is the case, add the replacement through the Parts menu.",
+      confirmText: "Mark as Working",
+      cancelText: "Cancel",
+      confirmClass: "bg-green-600 text-white hover:bg-green-700",
+      cancelClass: "bg-gray-200 text-gray-700 hover:bg-gray-300",
+    });
+
+  const confirmGoodPartAction = async (kind) =>
+    confirm({
+      title:
+        kind === "not_needed" ? "Mark as Not Needed?" : "Mark as Defective?",
+      message:
+        kind === "not_needed"
+          ? "Mark this replacement part as Not Needed only if the original part is actually good.\n\nThe replacement part should be moved back into inventory."
+          : "Mark this replacement part as Defective only if the replacement part itself is bad.\n\nThe replacement part should be moved to the scrap parts location.",
+      confirmText:
+        kind === "not_needed" ? "Mark as Not Needed" : "Mark as Defective",
+      cancelText: "Cancel",
+      confirmClass:
+        kind === "not_needed"
+          ? "bg-amber-600 text-white hover:bg-amber-700"
+          : "bg-red-600 text-white hover:bg-red-700",
+      cancelClass: "bg-gray-200 text-gray-700 hover:bg-gray-300",
+    });
+
   const ROOT_CAUSE_LOCATIONS = RESOLVED_LOCATION_NAMES;
   const showRootCauseControls = useMemo(() => {
     const movingToResolved = ROOT_CAUSE_LOCATIONS.includes(toLocationName);
     const inResolvedNow = ROOT_CAUSE_LOCATIONS.includes(currentLocation);
     return movingToResolved || inResolvedNow;
   }, [toLocationName, currentLocation]);
+
+  // --- PPID normalization (case-insensitive uniqueness) ---
+  const normPPID = (s) => (s || "").toUpperCase().trim();
+
+  // Will the unit still contain any GOOD parts after this submit?
+  const willHaveGoodAfterSubmit = useMemo(() => {
+    // 1) GOOD parts currently in unit
+    const goodInUnitNow = new Set(
+      (unitParts || [])
+        .filter((i) => i.is_functional === true)
+        .map((i) => normPPID(i.ppid)),
+    );
+
+    // 2) GOOD parts we are explicitly removing this submit
+    //    (only entries with an action AND an original_bad_ppid actually execute)
+    const gaEntries = Object.entries(goodActionByPPID).filter(
+      ([g, cfg]) => !!cfg?.action && !!cfg?.original_bad_ppid,
+    );
+    for (const [g] of gaEntries) goodInUnitNow.delete(normPPID(g));
+
+    // 3) GOOD parts that will be added this submit
+    const addFromGoodBlocks = goodBlocks.filter((b) => {
+      if (!b.part_id || !(b.current_bad_ppid || "").trim()) return false;
+
+      if (b.ppid === PULL_FROM_UNIT_VALUE) {
+        return !!(b.donor_ppid || "").trim();
+      }
+      return !!(b.ppid || "").trim();
+    }).length;
+
+    const addFromReplacements =
+      Object.values(replacementByOldPPID).filter(Boolean).length;
+
+    // If any good remains or any good is being added, we will end up with a good part in unit
+    return (
+      goodInUnitNow.size > 0 || addFromGoodBlocks > 0 || addFromReplacements > 0
+    );
+  }, [unitParts, goodActionByPPID, goodBlocks, replacementByOldPPID]);
 
   useEffect(() => {
     if (!showRootCauseControls) {
@@ -691,6 +816,7 @@ function SystemPage() {
 
         const isRMAto = RMA_LOCATION_NAMES.includes(toLocationName); // RMA VID/CID/PID
         const isL11to = toLocationName === L11_NAME; // "Sent to L11"
+        const shouldHideNtfForGoodPart = willHaveGoodAfterSubmit;
 
         // Base lists
         let catOpts = (cats || []).map((c) => ({
@@ -702,8 +828,9 @@ function SystemPage() {
           label: s.name,
         }));
 
-        // In RMA (VID/CID/PID): remove NTF from BOTH lists
-        if (isRMAto) {
+        // In RMA, or whenever a good part will remain attached to the unit:
+        // remove NTF from both lists.
+        if (isRMAto || shouldHideNtfForGoodPart) {
           catOpts = catOpts.filter((o) => o.label !== "NTF");
           baseSubOpts = baseSubOpts.filter(
             (o) => o.label !== "No Trouble Found",
@@ -779,7 +906,12 @@ function SystemPage() {
       alive = false;
     };
     // IMPORTANT: include selectedRootCauseId so sub options react to category changes
-  }, [showRootCauseControls, toLocationName, selectedRootCauseId]);
+  }, [
+    showRootCauseControls,
+    toLocationName,
+    selectedRootCauseId,
+    willHaveGoodAfterSubmit,
+  ]);
 
   useEffect(() => {
     // If the chosen category is NTF, keep sub-category locked to NTF (when available)
@@ -946,6 +1078,34 @@ function SystemPage() {
       cancelled = true;
     };
   }, [token, me?.isAdmin]);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    (async () => {
+      try {
+        const res = await getPendingL11MoveRule();
+        if (!cancelled) {
+          setPendingL11MoveRule({
+            enabled: !!res?.pending_l11_move_rule?.enabled,
+            minutes:
+              Number.parseInt(res?.pending_l11_move_rule?.minutes, 10) || 30,
+          });
+        }
+      } catch {
+        if (!cancelled) {
+          setPendingL11MoveRule({
+            enabled: false,
+            minutes: 30,
+          });
+        }
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   // Load parts when Good Parts flow is allowed (Debug → Debug/L10)
   useEffect(() => {
@@ -1135,6 +1295,11 @@ function SystemPage() {
       menu: (base) => ({
         ...base,
         overflow: "hidden",
+        zIndex: 40,
+      }),
+      menuPortal: (base) => ({
+        ...base,
+        zIndex: 40,
       }),
       menuList: (base) => ({
         ...base,
@@ -1151,8 +1316,6 @@ function SystemPage() {
     [],
   );
 
-  // --- PPID normalization (case-insensitive uniqueness) ---
-  const normPPID = (s) => (s || "").toUpperCase().trim();
   const safeToken = (s) =>
     String(s || "")
       .toUpperCase()
@@ -1749,41 +1912,6 @@ function SystemPage() {
     }
   };
 
-  // Will the unit still contain any GOOD parts after this submit?
-  const willHaveGoodAfterSubmit = useMemo(() => {
-    // 1) GOOD parts currently in unit
-    const goodInUnitNow = new Set(
-      (unitParts || [])
-        .filter((i) => i.is_functional === true)
-        .map((i) => normPPID(i.ppid)),
-    );
-
-    // 2) GOOD parts we are explicitly removing this submit
-    //    (only entries with an action AND an original_bad_ppid actually execute)
-    const gaEntries = Object.entries(goodActionByPPID).filter(
-      ([g, cfg]) => !!cfg?.action && !!cfg?.original_bad_ppid,
-    );
-    for (const [g] of gaEntries) goodInUnitNow.delete(normPPID(g));
-
-    // 3) GOOD parts that will be added this submit
-    const addFromGoodBlocks = goodBlocks.filter((b) => {
-      if (!b.part_id || !(b.current_bad_ppid || "").trim()) return false;
-
-      if (b.ppid === PULL_FROM_UNIT_VALUE) {
-        return !!(b.donor_ppid || "").trim();
-      }
-      return !!(b.ppid || "").trim();
-    }).length;
-
-    const addFromReplacements =
-      Object.values(replacementByOldPPID).filter(Boolean).length;
-
-    // If any good remains or any good is being added, we will end up with a good part in unit
-    return (
-      goodInUnitNow.size > 0 || addFromGoodBlocks > 0 || addFromReplacements > 0
-    );
-  }, [unitParts, goodActionByPPID, goodBlocks, replacementByOldPPID]);
-
   const L10_LOCATION_ID = useMemo(
     () => locations.find((l) => l.name === "In L10")?.id,
     [locations],
@@ -1843,7 +1971,9 @@ function SystemPage() {
       return;
     }
 
-    const movingToPending = toId === 4;
+    const movingToPendingParts = toId === pendingPartsLocationId;
+    const movingToPendingMrb =
+      pendingMrbLocationId != null && toId === pendingMrbLocationId;
     const newBadCount = pendingBlocks.filter((b) => b.part_id).length;
 
     // any currently-tracked BAD parts in the unit?
@@ -1851,7 +1981,7 @@ function SystemPage() {
       (i) => i.is_functional === false,
     );
 
-    if (movingToPending) {
+    if (movingToPendingParts) {
       if (isInPendingParts) {
         // keep existing behavior while already IN Pending Parts
         if (newBadCount === 0) {
@@ -1871,11 +2001,42 @@ function SystemPage() {
       }
     }
 
+    const remainingTrackedBadCount = (unitParts || []).filter(
+      (item) =>
+        item.is_functional === false &&
+        !toRemovePPIDs.has(item.ppid) &&
+        !replacementByOldPPID[item.ppid],
+    ).length;
+
+    if (movingToPendingMrb && remainingTrackedBadCount + newBadCount === 0) {
+      setFormError(PENDING_MRB_REQUIRED_BAD_ERROR);
+      return;
+    }
+
+    if (movingToPendingMrb && willHaveGoodAfterSubmit) {
+      setFormError(PENDING_MRB_GOOD_PARTS_ERROR);
+      return;
+    }
+
+    if (movingToPendingMrb && !hasSystemFolderEvidence) {
+      setFormError(
+        "Add evidence (logs or photos) before moving to Pending MRB.",
+      );
+      return;
+    }
+
+    if (movingToPendingMrb && !hasFreshPhotoEvidenceForCid) {
+      setFormError(
+        "Photo evidence of the damage must be uploaded before Pending MRB.",
+      );
+      return;
+    }
+
     const movingToL10 =
       toId === (locations.find((l) => l.name === "In L10")?.id ?? 5);
 
     // Rule #4: if a BAD part is being added AND there exists GOOD inventory of that part, block submit
-    if (pendingBlocks.length > 0) {
+    if (movingToPendingParts && pendingBlocks.length > 0) {
       for (const b of pendingBlocks) {
         if (!b.part_id) continue;
         const invGood = await getPartItems({
@@ -1912,81 +2073,14 @@ function SystemPage() {
     const toCreate = pendingBlocks.filter((b) => b.part_id);
     const removing = Array.from(toRemovePPIDs || []);
 
-    if (toId === 4) {
-      const up = (s) => (s || "").toUpperCase().trim();
-      const formatPartWithDpn = (i) => {
-        const name =
-          (i?.part_name && i.part_name.trim()) ||
-          (i?.part_id != null
-            ? partNameById.get(i.part_id) || `#${i.part_id}`
-            : "Part");
-        const dpn =
-          i?.part_dpn || (i?.part_id != null ? partDpnById.get(i.part_id) : "");
-        return dpn ? `${name} [${dpn}]` : name;
-      };
-
-      // PPID -> current item in unit (so we can read part_id/name)
-      const byPPID = new Map((unitParts || []).map((i) => [up(i.ppid), i]));
-
-      // 1) start with BADs currently in the unit
-      const badNow = new Map(); // PPID -> item
-      for (const i of unitParts || []) {
-        if (i.is_functional === false) badNow.set(up(i.ppid), i);
-      }
-
-      // 2) remove BADs marked as working
-      for (const p of toRemovePPIDs) badNow.delete(up(p));
-
-      // 3) remove BADs that will be replaced by a GOOD PPID
-      for (const oldBad of Object.keys(replacementByOldPPID || {})) {
-        if ((replacementByOldPPID[oldBad] || "").trim())
-          badNow.delete(up(oldBad));
-      }
-
-      // 4) add newly flagged BADs (pending blocks)
-      for (const b of pendingBlocks) {
-        if (b.part_id) {
-          const pseudoPpid = `TMP-${b.id}`;
-          // synthesize a minimal item so nameOfPart works
-          badNow.set(pseudoPpid, {
-            part_id: b.part_id,
-            part_name: null,
-            part_dpn: partDpnById.get(b.part_id) || "",
-            ppid: pseudoPpid,
-          });
-        }
-      }
-
-      // 5) add BADs brought back via GOOD-part actions
-      for (const [goodPPID, cfg] of Object.entries(goodActionByPPID || {})) {
-        const back = (cfg?.original_bad_ppid || "").trim();
-        if (!cfg?.action || !back) continue;
-        const goodItem = byPPID.get(up(goodPPID)); // infer part info from the good in unit
-        badNow.set(up(back), {
-          part_id: goodItem?.part_id ?? null,
-          part_name: goodItem?.part_name ?? null,
-          ppid: up(back),
-        });
-      }
-
-      // Build label lines for EVERY remaining BAD PPID (no name-based dedupe)
-      const labelLines = Array.from(badNow.entries())
-        .map(([, info]) => formatPartWithDpn(info))
-        .sort((a, b) => a.localeCompare(b));
-
-      const blob = await pdf(
-        <SystemPendingPartsLabel parts={labelLines} />,
-      ).toBlob();
-      const url = URL.createObjectURL(blob);
-      window.open(url);
-    }
-
     // ---- Existing note lines (Pending Parts) ----
     // ---- Existing note lines (Pending Parts) ----
     const addedNotes = toCreate.map((b) => {
       const name = partNameById.get(b.part_id) || `#${b.part_id}`;
       const dpn = partDpnById.get(b.part_id) || "N/A";
-      return ` - ${name} [${dpn}] in system identified as non working with none in stock.`;
+      return movingToPendingMrb
+        ? ` - ${name} [${dpn}] tracked in the system as estimated CID damage.`
+        : ` - ${name} [${dpn}] in system identified as non working with none in stock.`;
     });
 
     const removedNotes = removing.map((ppid) => {
@@ -2243,6 +2337,91 @@ function SystemPage() {
         "Root Cause and Sub Category are required when moving to RMA (VID/CID/PID), Sent to L11, or Sent for Dell Repair.",
       );
       return;
+    }
+
+    if (movingToPendingMrb) {
+      const confirmed = await confirm({
+        title: "Move to Pending MRB",
+        message:
+          "Make sure all estimated CID-damaged parts are tracked in the system before moving to Pending MRB.",
+        confirmText: "Continue",
+        cancelText: "Cancel",
+        confirmClass: "bg-amber-600 text-white hover:bg-amber-700",
+        cancelClass: "bg-gray-200 text-gray-700 hover:bg-gray-300",
+      });
+      if (!confirmed) return;
+    }
+
+    if (movingToPendingParts || movingToPendingMrb) {
+      const up = (s) => (s || "").toUpperCase().trim();
+      const formatPartWithDpn = (i) => {
+        const name =
+          (i?.part_name && i.part_name.trim()) ||
+          (i?.part_id != null
+            ? partNameById.get(i.part_id) || `#${i.part_id}`
+            : "Part");
+        const dpn =
+          i?.part_dpn || (i?.part_id != null ? partDpnById.get(i.part_id) : "");
+        return dpn ? `${name} [${dpn}]` : name;
+      };
+
+      // PPID -> current item in unit (so we can read part_id/name)
+      const byPPID = new Map((unitParts || []).map((i) => [up(i.ppid), i]));
+
+      // 1) start with BADs currently in the unit
+      const badNow = new Map(); // PPID -> item
+      for (const i of unitParts || []) {
+        if (i.is_functional === false) badNow.set(up(i.ppid), i);
+      }
+
+      // 2) remove BADs marked as working
+      for (const p of toRemovePPIDs) badNow.delete(up(p));
+
+      // 3) remove BADs that will be replaced by a GOOD PPID
+      for (const oldBad of Object.keys(replacementByOldPPID || {})) {
+        if ((replacementByOldPPID[oldBad] || "").trim())
+          badNow.delete(up(oldBad));
+      }
+
+      // 4) add newly flagged BADs (pending blocks)
+      for (const b of pendingBlocks) {
+        if (b.part_id) {
+          const pseudoPpid = `TMP-${b.id}`;
+          // synthesize a minimal item so nameOfPart works
+          badNow.set(pseudoPpid, {
+            part_id: b.part_id,
+            part_name: null,
+            part_dpn: partDpnById.get(b.part_id) || "",
+            ppid: pseudoPpid,
+          });
+        }
+      }
+
+      // 5) add BADs brought back via GOOD-part actions
+      for (const [goodPPID, cfg] of Object.entries(goodActionByPPID || {})) {
+        const back = (cfg?.original_bad_ppid || "").trim();
+        if (!cfg?.action || !back) continue;
+        const goodItem = byPPID.get(up(goodPPID)); // infer part info from the good in unit
+        badNow.set(up(back), {
+          part_id: goodItem?.part_id ?? null,
+          part_name: goodItem?.part_name ?? null,
+          ppid: up(back),
+        });
+      }
+
+      // Build label lines for EVERY remaining BAD PPID (no name-based dedupe)
+      const labelLines = Array.from(badNow.entries())
+        .map(([, info]) => formatPartWithDpn(info))
+        .sort((a, b) => a.localeCompare(b));
+
+      const blob = await pdf(
+        <SystemPendingPartsLabel
+          parts={labelLines}
+          title={movingToPendingMrb ? PENDING_MRB_NAME : PENDING_PARTS_NAME}
+        />,
+      ).toBlob();
+      const url = URL.createObjectURL(blob);
+      window.open(url);
     }
 
     // // Hard rule for L11: both category and sub-category must be NTF
@@ -2853,7 +3032,9 @@ function SystemPage() {
 
     // If there are bad parts, ask which label to print
     if (hasBadParts) {
-      const choice = await confirmPrintPendingParts(); // 'id' or 'parts' | null
+      const choice = await confirmPrintPendingParts(
+        currentLocation === PENDING_MRB_NAME ? PENDING_MRB_NAME : PENDING_PARTS_NAME
+      ); // 'id' or 'parts' | null
       if (!choice) return;
 
       if (choice === "parts") {
@@ -2863,7 +3044,14 @@ function SystemPage() {
           .sort((a, b) => a.localeCompare(b));
 
         const blob = await pdf(
-          <SystemPendingPartsLabel parts={labelLines} />,
+          <SystemPendingPartsLabel
+            parts={labelLines}
+            title={
+              currentLocation === PENDING_MRB_NAME
+                ? PENDING_MRB_NAME
+                : PENDING_PARTS_NAME
+            }
+          />,
         ).toBlob();
         const url = URL.createObjectURL(blob);
         window.open(url);
@@ -3255,10 +3443,13 @@ function SystemPage() {
                         ).map((loc) => {
                           const isRMA = RMA_LOCATION_IDS.includes(loc.id);
                           const isRmaCid = loc.name === "RMA CID";
+                          const isPendingMrbDestination =
+                            loc.name === PENDING_MRB_NAME;
                           const evidenceRequiredBlockedDestinations = new Set([
                             "RMA VID",
                             "RMA PID",
                             "Sent to L11",
+                            PENDING_MRB_NAME,
                           ]);
                           const isEvidenceRequiredDestination =
                             evidenceRequiredBlockedDestinations.has(loc.name);
@@ -3276,6 +3467,14 @@ function SystemPage() {
                             !hasSystemFolderEvidence;
                           const pendingL11GoodPartsBlocked =
                             isPendingL11Destination && willHaveGoodAfterSubmit;
+                          const pendingMrbGoodPartsBlocked =
+                            isPendingMrbDestination && willHaveGoodAfterSubmit;
+                          const pendingMrbPhotoBlocked =
+                            isPendingMrbDestination &&
+                            !hasFreshPhotoEvidenceForCid;
+                          const pendingL11TimeBlocked =
+                            isPendingL11Destination &&
+                            pendingL11MoveRuleRemainingMinutes > 0;
                           // Allow In L10 when at least one bad has a Replacement PPID chosen
                           const l10Blocked =
                             isL10 &&
@@ -3290,7 +3489,10 @@ function SystemPage() {
                             evidenceBlocked ||
                             l10Blocked ||
                             l11Blocked ||
-                            pendingL11GoodPartsBlocked;
+                            pendingL11TimeBlocked ||
+                            pendingL11GoodPartsBlocked ||
+                            pendingMrbGoodPartsBlocked ||
+                            pendingMrbPhotoBlocked;
 
                           const title = l11Blocked
                             ? "L11 Logs Already Present"
@@ -3298,15 +3500,23 @@ function SystemPage() {
                               ? "Remove/return all good parts before moving to an RMA location."
                               : cidPhotoBlocked
                                 ? "Photo evidence of the damage must be uploaded before moving to RMA CID."
-                                : evidenceBlocked
-                                  ? "Evidence must be added before moving to this location."
-                                  : pendingL11GoodPartsBlocked
-                                    ? "Return/remove all good parts before moving to Pending L11 Logs"
-                                    : l10Blocked
-                                      ? "Add a Replacement PPID for at least one defective part to move to In L10."
-                                      : isResolved
-                                        ? "Resolved units can’t be moved."
-                                        : undefined;
+                                : pendingMrbPhotoBlocked
+                                  ? "Photo evidence of the damage must be uploaded before Pending MRB."
+                                  : evidenceBlocked
+                                    ? isPendingMrbDestination
+                                      ? "Add evidence (logs or photos) before moving to Pending MRB."
+                                      : "Evidence must be added before moving to this location."
+                                    : pendingL11TimeBlocked
+                                      ? `Wait ${pendingL11MoveRuleRemainingMinutes} more minute${pendingL11MoveRuleRemainingMinutes === 1 ? "" : "s"} so pending MFT log downloads can finish.`
+                                      : pendingMrbGoodPartsBlocked
+                                        ? PENDING_MRB_GOOD_PARTS_ERROR
+                                        : pendingL11GoodPartsBlocked
+                                          ? "Return/remove all good parts before moving to Pending L11 Logs"
+                                          : l10Blocked
+                                            ? "Add a Replacement PPID for at least one defective part to move to In L10."
+                                            : isResolved
+                                              ? "Resolved units can’t be moved."
+                                              : undefined;
 
                           return (
                             <Tooltip
@@ -3346,15 +3556,20 @@ function SystemPage() {
                   <div className="mt-5 flex flex-col gap-4">
                     <div className="flex items-center justify-between">
                       {(isInPendingParts &&
-                        toLocationId === 4 &&
-                        system?.location === "Pending Parts") ||
-                      (!isInPendingParts && toLocationId === 4) ? (
+                        toLocationId === pendingPartsLocationId &&
+                        system?.location === PENDING_PARTS_NAME) ||
+                      (isInPendingMrb &&
+                        toLocationId === pendingMrbLocationId &&
+                        system?.location === PENDING_MRB_NAME) ||
+                      (!isInPendingParts &&
+                        !isInPendingMrb &&
+                        isPendingTrackingDestination) ? (
                         <button
                           type="button"
                           onClick={addBadPartBlock}
                           className="px-3 py-1.5 rounded-lg bg-red-600 text-white hover:bg-red-700"
                         >
-                          + Add Pending Part
+                          {pendingTrackingActionLabel}
                         </button>
                       ) : null}
                       {canAddGoodParts && repairsAllowed !== false && (
@@ -3382,215 +3597,141 @@ function SystemPage() {
                             Replacement Parts to be install into the unit
                           </label>
 
-                          {goodBlocks.map((block) => {
-                            const partValue =
-                              flatPartOptions.find(
-                                (o) => o.value === block.part_id,
-                              ) || null;
+                          <div
+                            className={
+                              goodBlocks.length > 5
+                                ? "max-h-[34rem] overflow-y-auto pr-2 space-y-3"
+                                : "overflow-y-hidden pr-2 space-y-3"
+                            }
+                            style={{ scrollbarGutter: "stable" }}
+                          >
+                            {goodBlocks.map((block) => {
+                              const partValue =
+                                flatPartOptions.find(
+                                  (o) => o.value === block.part_id,
+                                ) || null;
 
-                            return (
-                              <div
-                                key={block.id}
-                                className="border rounded-lg p-3 bg-white shadow-sm space-y-3 pb-5"
-                              >
-                                {/* Row 1: main 3 fields + Cancel */}
-                                <div className="flex flex-col md:flex-row md:items-center gap-3">
-                                  {/* Part Select */}
-                                  <div className="flex-1 min-w-0">
-                                    <label className="block text-sm font-medium text-gray-700 mb-1">
-                                      Part
-                                    </label>
-                                    <Select
-                                      isDisabled={formDisabled}
-                                      instanceId={`good-part-${block.id}`}
-                                      classNamePrefix="react-select"
-                                      styles={select40Styles}
-                                      isClearable
-                                      isSearchable
-                                      placeholder="Select part"
-                                      value={partValue}
-                                      onChange={async (opt) => {
-                                        updateGoodBlock(
-                                          block.id,
-                                          "part_id",
-                                          opt ? opt.value : null,
-                                        );
-                                        if (opt?.value)
-                                          await loadGoodOptions(opt.value);
-                                      }}
-                                      options={partOptions}
-                                      filterOption={filterPartOption}
-                                      components={{ Option: PartOption }}
-                                      formatGroupLabel={PartGroupLabel}
-                                    />
-                                  </div>
-
-                                  {/* Replacement PPID */}
-                                  <div className="flex-1 min-w-0">
-                                    <label className="block text-sm font-medium text-gray-700 mb-1">
-                                      Replacement PPID
-                                    </label>
-                                    <Select
-                                      instanceId={`good-ppid-${block.id}`}
-                                      classNamePrefix="react-select"
-                                      styles={select40Styles}
-                                      placeholder={
-                                        block.part_id
-                                          ? "Select PPID"
-                                          : "Pick a part first"
-                                      }
-                                      isDisabled={
-                                        !block.part_id || formDisabled
-                                      }
-                                      value={
-                                        block.ppid
-                                          ? block.ppid === PULL_FROM_UNIT_VALUE
-                                            ? {
-                                                value: PULL_FROM_UNIT_VALUE,
-                                                label: "Pull from Unit",
-                                                isSpecial: true,
-                                              }
-                                            : {
-                                                value: block.ppid,
-                                                label: block.ppid,
-                                              }
-                                          : null
-                                      }
-                                      onMenuOpen={async () => {
-                                        if (block.part_id)
-                                          await loadGoodOptions(block.part_id);
-                                      }}
-                                      onChange={(opt) => {
-                                        const next = opt ? opt.value : "";
-                                        if (
-                                          next &&
-                                          next !== PULL_FROM_UNIT_VALUE
-                                        ) {
-                                          setReplacementByOldPPID((prev) => {
-                                            const copy = { ...prev };
-                                            for (const k of Object.keys(copy)) {
-                                              if (
-                                                normPPID(copy[k]) ===
-                                                normPPID(next)
-                                              )
-                                                copy[k] = "";
-                                            }
-                                            return copy;
-                                          });
-                                        }
-                                        updateGoodBlock(block.id, "ppid", next);
-                                      }}
-                                      options={[
-                                        ...((block.part_id &&
-                                          getFilteredGoodOptions(
-                                            block.part_id,
-                                            block.ppid,
-                                          )) ||
-                                          []),
-                                        {
-                                          value: PULL_FROM_UNIT_VALUE,
-                                          label: "Pull from Unit",
-                                          isSpecial: true,
-                                        },
-                                      ]}
-                                      components={{
-                                        Option: GoodPPIDOption,
-                                        SingleValue: GoodPPIDSingleValue,
-                                      }}
-                                    />
-                                  </div>
-
-                                  {/* Current Defective PPID */}
-                                  <div className="flex-1 min-w-0">
-                                    <label className="block text-sm font-medium text-gray-700 mb-1">
-                                      Current Defective PPID
-                                    </label>
-                                    <input
-                                      type="text"
-                                      inputMode="text"
-                                      autoCapitalize="characters"
-                                      autoCorrect="off"
-                                      spellCheck="false"
-                                      placeholder="Scan or type PPID"
-                                      value={block.current_bad_ppid}
-                                      onChange={(e) =>
-                                        updateGoodBlock(
-                                          block.id,
-                                          "current_bad_ppid",
-                                          e.target.value,
-                                        )
-                                      }
-                                      onBlur={(e) =>
-                                        updateGoodBlock(
-                                          block.id,
-                                          "current_bad_ppid",
-                                          e.target.value.toUpperCase().trim(),
-                                        )
-                                      }
-                                      className={`w-full h-10 rounded-md border px-3 focus:outline-none focus:ring-2 focus:ring-blue-500 ${
-                                        !block.current_bad_ppid ||
-                                        !block.part_id
-                                          ? "border-amber-300"
-                                          : "border-gray-300"
-                                      }`}
-                                    />
-                                  </div>
-
-                                  {/* Remove */}
-                                  <div className="md:w-auto">
-                                    <button
-                                      type="button"
-                                      onClick={() => removeGoodBlock(block.id)}
-                                      className="relative px-3 py-2 rounded-md bg-red-600 hover:bg-red-700 text-white mt-5 whitespace-nowrap"
-                                    >
-                                      <span className="invisible block">
-                                        Cancel
-                                      </span>
-                                      <span className="absolute inset-0 flex items-center justify-center">
-                                        Cancel
-                                      </span>
-                                    </button>
-                                  </div>
-                                </div>
-
-                                {/* Row 2: Donor Unit + PPID in a wire box */}
-                                {block.ppid === PULL_FROM_UNIT_VALUE && (
-                                  <div className="mt-1 border border-blue-300 rounded-lg p-3 bg-blue-50/40 flex flex-col md:flex-row gap-3">
+                              return (
+                                <div
+                                  key={block.id}
+                                  className="border rounded-lg p-3 bg-white shadow-sm space-y-3 pb-5"
+                                >
+                                  {/* Row 1: main 3 fields + Cancel */}
+                                  <div className="flex flex-col md:flex-row md:items-center gap-3">
+                                    {/* Part Select */}
                                     <div className="flex-1 min-w-0">
                                       <label className="block text-sm font-medium text-gray-700 mb-1">
-                                        Donor Unit
+                                        Part
                                       </label>
                                       <Select
-                                        instanceId={`donor-unit-${block.id}`}
+                                        isDisabled={formDisabled}
+                                        instanceId={`good-part-${block.id}`}
                                         classNamePrefix="react-select"
                                         styles={select40Styles}
-                                        placeholder="Select donor unit"
                                         isClearable
                                         isSearchable
-                                        isDisabled={formDisabled}
-                                        value={
-                                          block.donor_unit_id
-                                            ? donorUnitOptions.find(
-                                                (o) =>
-                                                  o.value ===
-                                                  block.donor_unit_id,
-                                              ) || null
-                                            : null
-                                        }
-                                        onChange={(opt) =>
+                                        placeholder="Select part"
+                                        value={partValue}
+                                        onChange={async (opt) => {
                                           updateGoodBlock(
                                             block.id,
-                                            "donor_unit_id",
+                                            "part_id",
                                             opt ? opt.value : null,
-                                          )
-                                        }
-                                        options={donorUnitOptions}
+                                          );
+                                          if (opt?.value)
+                                            await loadGoodOptions(opt.value);
+                                        }}
+                                        options={partOptions}
+                                        filterOption={filterPartOption}
+                                        components={{ Option: PartOption }}
+                                        formatGroupLabel={PartGroupLabel}
                                       />
                                     </div>
 
+                                    {/* Replacement PPID */}
                                     <div className="flex-1 min-w-0">
                                       <label className="block text-sm font-medium text-gray-700 mb-1">
-                                        PPID
+                                        Replacement PPID
+                                      </label>
+                                      <Select
+                                        instanceId={`good-ppid-${block.id}`}
+                                        classNamePrefix="react-select"
+                                        styles={select40Styles}
+                                        placeholder={
+                                          block.part_id
+                                            ? "Select PPID"
+                                            : "Pick a part first"
+                                        }
+                                        isDisabled={
+                                          !block.part_id || formDisabled
+                                        }
+                                        value={
+                                          block.ppid
+                                            ? block.ppid ===
+                                              PULL_FROM_UNIT_VALUE
+                                              ? {
+                                                  value: PULL_FROM_UNIT_VALUE,
+                                                  label: "Pull from Unit",
+                                                  isSpecial: true,
+                                                }
+                                              : {
+                                                  value: block.ppid,
+                                                  label: block.ppid,
+                                                }
+                                            : null
+                                        }
+                                        onMenuOpen={async () => {
+                                          if (block.part_id)
+                                            await loadGoodOptions(block.part_id);
+                                        }}
+                                        onChange={(opt) => {
+                                          const next = opt ? opt.value : "";
+                                          if (
+                                            next &&
+                                            next !== PULL_FROM_UNIT_VALUE
+                                          ) {
+                                            setReplacementByOldPPID((prev) => {
+                                              const copy = { ...prev };
+                                              for (const k of Object.keys(copy)) {
+                                                if (
+                                                  normPPID(copy[k]) ===
+                                                  normPPID(next)
+                                                )
+                                                  copy[k] = "";
+                                              }
+                                              return copy;
+                                            });
+                                          }
+                                          updateGoodBlock(
+                                            block.id,
+                                            "ppid",
+                                            next,
+                                          );
+                                        }}
+                                        options={[
+                                          ...((block.part_id &&
+                                            getFilteredGoodOptions(
+                                              block.part_id,
+                                              block.ppid,
+                                            )) ||
+                                            []),
+                                          {
+                                            value: PULL_FROM_UNIT_VALUE,
+                                            label: "Pull from Unit",
+                                            isSpecial: true,
+                                          },
+                                        ]}
+                                        components={{
+                                          Option: GoodPPIDOption,
+                                          SingleValue: GoodPPIDSingleValue,
+                                        }}
+                                      />
+                                    </div>
+
+                                    {/* Current Defective PPID */}
+                                    <div className="flex-1 min-w-0">
+                                      <label className="block text-sm font-medium text-gray-700 mb-1">
+                                        Current Defective PPID
                                       </label>
                                       <input
                                         type="text"
@@ -3599,111 +3740,220 @@ function SystemPage() {
                                         autoCorrect="off"
                                         spellCheck="false"
                                         placeholder="Scan or type PPID"
-                                        value={block.donor_ppid}
+                                        value={block.current_bad_ppid}
                                         onChange={(e) =>
                                           updateGoodBlock(
                                             block.id,
-                                            "donor_ppid",
+                                            "current_bad_ppid",
                                             e.target.value,
                                           )
                                         }
                                         onBlur={(e) =>
                                           updateGoodBlock(
                                             block.id,
-                                            "donor_ppid",
+                                            "current_bad_ppid",
                                             e.target.value.toUpperCase().trim(),
                                           )
                                         }
                                         className={`w-full h-10 rounded-md border px-3 focus:outline-none focus:ring-2 focus:ring-blue-500 ${
-                                          !block.donor_ppid ||
-                                          !block.donor_unit_id
+                                          !block.current_bad_ppid ||
+                                          !block.part_id
                                             ? "border-amber-300"
                                             : "border-gray-300"
                                         }`}
                                       />
                                     </div>
+
+                                    {/* Remove */}
+                                    <div className="md:w-auto">
+                                      <button
+                                        type="button"
+                                        onClick={() => removeGoodBlock(block.id)}
+                                        className="relative px-3 py-2 rounded-md bg-red-600 hover:bg-red-700 text-white mt-5 whitespace-nowrap"
+                                      >
+                                        <span className="invisible block">
+                                          Cancel
+                                        </span>
+                                        <span className="absolute inset-0 flex items-center justify-center">
+                                          Cancel
+                                        </span>
+                                      </button>
+                                    </div>
                                   </div>
-                                )}
-                              </div>
-                            );
-                          })}
+
+                                  {/* Row 2: Donor Unit + PPID in a wire box */}
+                                  {block.ppid === PULL_FROM_UNIT_VALUE && (
+                                    <div className="mt-1 border border-blue-300 rounded-lg p-3 bg-blue-50/40 flex flex-col md:flex-row gap-3">
+                                      <div className="flex-1 min-w-0">
+                                        <label className="block text-sm font-medium text-gray-700 mb-1">
+                                          Donor Unit
+                                        </label>
+                                        <Select
+                                          instanceId={`donor-unit-${block.id}`}
+                                          classNamePrefix="react-select"
+                                          styles={select40Styles}
+                                          placeholder="Select donor unit"
+                                          isClearable
+                                          isSearchable
+                                          isDisabled={formDisabled}
+                                          value={
+                                            block.donor_unit_id
+                                              ? donorUnitOptions.find(
+                                                  (o) =>
+                                                    o.value ===
+                                                    block.donor_unit_id,
+                                                ) || null
+                                              : null
+                                          }
+                                          onChange={(opt) =>
+                                            updateGoodBlock(
+                                              block.id,
+                                              "donor_unit_id",
+                                              opt ? opt.value : null,
+                                            )
+                                          }
+                                          options={donorUnitOptions}
+                                        />
+                                      </div>
+
+                                      <div className="flex-1 min-w-0">
+                                        <label className="block text-sm font-medium text-gray-700 mb-1">
+                                          PPID
+                                        </label>
+                                        <input
+                                          type="text"
+                                          inputMode="text"
+                                          autoCapitalize="characters"
+                                          autoCorrect="off"
+                                          spellCheck="false"
+                                          placeholder="Scan or type PPID"
+                                          value={block.donor_ppid}
+                                          onChange={(e) =>
+                                            updateGoodBlock(
+                                              block.id,
+                                              "donor_ppid",
+                                              e.target.value,
+                                            )
+                                          }
+                                          onBlur={(e) =>
+                                            updateGoodBlock(
+                                              block.id,
+                                              "donor_ppid",
+                                              e.target.value.toUpperCase().trim(),
+                                            )
+                                          }
+                                          className={`w-full h-10 rounded-md border px-3 focus:outline-none focus:ring-2 focus:ring-blue-500 ${
+                                            !block.donor_ppid ||
+                                            !block.donor_unit_id
+                                              ? "border-amber-300"
+                                              : "border-gray-300"
+                                          }`}
+                                        />
+                                      </div>
+                                    </div>
+                                  )}
+                                </div>
+                              );
+                            })}
+                          </div>
                         </div>
                       ))}
 
                     {(isInPendingParts &&
-                      toLocationId === 4 &&
-                      system?.location === "Pending Parts") ||
-                    (!isInPendingParts && toLocationId === 4) ? (
+                      toLocationId === pendingPartsLocationId &&
+                      system?.location === PENDING_PARTS_NAME) ||
+                    (isInPendingMrb &&
+                      toLocationId === pendingMrbLocationId &&
+                      system?.location === PENDING_MRB_NAME) ||
+                    (!isInPendingParts &&
+                      !isInPendingMrb &&
+                      isPendingTrackingDestination) ? (
                       <>
                         {/* New blocks to add */}
+                        <label className="block text-sm font-medium text-gray-600">
+                          {pendingTrackingSectionLabel}
+                        </label>
                         {pendingBlocks.length === 0 ? (
                           <div className="text-sm text-gray-500 border border-dashed border-gray-300 rounded-lg p-4">
-                            No pending parts to be added. Click “Add Pending
-                            Part” to begin.
+                            {pendingTrackingEmptyLabel}
                           </div>
                         ) : (
                           <div className="space-y-3">
-                            <label className="block text-sm font-medium text-gray-600">
-                              Pending Parts the unit will need
-                            </label>
-                            {pendingBlocks.map((block) => {
-                              const partValue =
-                                flatPartOptions.find(
-                                  (o) => o.value === block.part_id,
-                                ) || null;
-                              return (
-                                <div
-                                  key={block.id}
-                                  className="border rounded-lg p-3 bg-white shadow-sm flex flex-col md:flex-row md:items-center gap-3 pb-5"
-                                >
-                                  {/* Part Select */}
-                                  <div className="flex-1 min-w-0">
-                                    <label className="block text-sm font-medium text-gray-700 mb-1">
-                                      Part Needed
-                                    </label>
-                                    <Select
-                                      isDisabled={formDisabled}
-                                      instanceId={`part-${block.id}`}
-                                      classNamePrefix="react-select"
-                                      styles={select40Styles}
-                                      isClearable
-                                      isSearchable
-                                      placeholder="Select part"
-                                      value={partValue}
-                                      onChange={(opt) =>
-                                        updateBlock(
-                                          block.id,
-                                          "part_id",
-                                          opt ? opt.value : null,
-                                        )
-                                      }
-                                      options={pendingPartOptions} // grouped: only parts with functional inventory qty = 0
-                                      filterOption={filterPartOption} // search by part OR category
-                                      components={{ Option: PartOption }} // show category chip on each option
-                                      formatGroupLabel={PartGroupLabel} // non-selectable group headers
-                                    />
-                                  </div>
+                            <div
+                              className={
+                                pendingBlocks.length > 5
+                                  ? "max-h-[34rem] overflow-y-auto pr-2 space-y-3"
+                                  : "overflow-y-hidden pr-2 space-y-3"
+                              }
+                              style={{ scrollbarGutter: "stable" }}
+                            >
+                              {pendingBlocks.map((block) => {
+                                const partValue =
+                                  flatPartOptions.find(
+                                    (o) => o.value === block.part_id,
+                                  ) || null;
+                                return (
+                                  <div
+                                    key={block.id}
+                                    className="border rounded-lg p-3 bg-white shadow-sm flex flex-col md:flex-row md:items-center gap-3 pb-5"
+                                  >
+                                    {/* Part Select */}
+                                    <div className="flex-1 min-w-0">
+                                      <label className="block text-sm font-medium text-gray-700 mb-1">
+                                        {toLocationName === PENDING_MRB_NAME
+                                          ? "Defective Part"
+                                          : "Part Needed"}
+                                      </label>
+                                      <Select
+                                        isDisabled={formDisabled}
+                                        instanceId={`part-${block.id}`}
+                                        classNamePrefix="react-select"
+                                        styles={select40Styles}
+                                        menuPortalTarget={
+                                          typeof document !== "undefined"
+                                            ? document.body
+                                            : null
+                                        }
+                                        menuPosition="fixed"
+                                        isClearable
+                                        isSearchable
+                                        placeholder="Select part"
+                                        value={partValue}
+                                        onChange={(opt) =>
+                                          updateBlock(
+                                            block.id,
+                                            "part_id",
+                                            opt ? opt.value : null,
+                                          )
+                                        }
+                                        options={pendingTrackingPartOptions}
+                                        filterOption={filterPartOption} // search by part OR category
+                                        components={{ Option: PartOption }} // show category chip on each option
+                                        formatGroupLabel={PartGroupLabel} // non-selectable group headers
+                                      />
+                                    </div>
 
-                                  <div className="md:w-auto">
-                                    <button
-                                      type="button"
-                                      onClick={() => removeBlock(block.id)}
-                                      className="relative px-3 py-2 rounded-md bg-red-600 hover:bg-red-700 text-white mt-5 whitespace-nowrap"
-                                    >
-                                      {/* Ghost sets the width to the longest label */}
-                                      <span className="invisible block">
-                                        Mark as Working
-                                      </span>
+                                    <div className="md:w-auto">
+                                      <button
+                                        type="button"
+                                        onClick={() => removeBlock(block.id)}
+                                        className="relative px-3 py-2 rounded-md bg-red-600 hover:bg-red-700 text-white mt-5 whitespace-nowrap"
+                                      >
+                                        {/* Ghost sets the width to the longest label */}
+                                        <span className="invisible block">
+                                          Mark as Working
+                                        </span>
 
-                                      {/* Real label centered on top */}
-                                      <span className="absolute inset-0 flex items-center justify-center">
-                                        Cancel
-                                      </span>
-                                    </button>
+                                        {/* Real label centered on top */}
+                                        <span className="absolute inset-0 flex items-center justify-center">
+                                          Cancel
+                                        </span>
+                                      </button>
+                                    </div>
                                   </div>
-                                </div>
-                              );
-                            })}
+                                );
+                              })}
+                            </div>
                           </div>
                         )}
                       </>
@@ -3898,24 +4148,28 @@ function SystemPage() {
                                           <button
                                             disabled={disableMark}
                                             type="button"
-                                            onClick={() => {
+                                            onClick={async () => {
+                                              const isQueued =
+                                                toRemovePPIDs.has(item.ppid);
+                                              if (!isQueued) {
+                                                const confirmed =
+                                                  await confirmMarkAsWorking();
+                                                if (!confirmed) return;
+                                              }
+
                                               // Toggle mark-as-working, and if marking -> clear any replacement chosen
                                               toggleRemovePPID(item.ppid);
                                               setReplacementByOldPPID((s) => {
                                                 const next = { ...s };
                                                 // If we just queued Mark as Working, nuke the replacement
-                                                if (
-                                                  !toRemovePPIDs.has(item.ppid)
-                                                ) {
+                                                if (!isQueued) {
                                                   next[item.ppid] = "";
                                                 }
                                                 return next;
                                               });
                                               setOriginalPPIDByBadPPID((s) => {
                                                 const next = { ...s };
-                                                if (
-                                                  !toRemovePPIDs.has(item.ppid)
-                                                ) {
+                                                if (!isQueued) {
                                                   next[item.ppid] = "";
                                                 }
                                                 return next;
@@ -4121,6 +4375,10 @@ function SystemPage() {
 
                                       return;
                                     }
+
+                                    const confirmed =
+                                      await confirmGoodPartAction(kind);
+                                    if (!confirmed) return;
 
                                     // Set new action (keep current original_bad_ppid if present)
                                     setGoodActionByPPID((prev) => ({


### PR DESCRIPTION
**Backend**

- Added Pending MRB as a new system location, including DB migration and init seed updates.
- Added configurable Pending L11 Logs wait-rule support through global_settings, plus new server endpoints to read/update that setting.
- Added backend enforcement for the Pending L11 wait period after the latest move into Received.
- Extended movement validation for Pending MRB to require evidence, fresh photo evidence, and tracked defective parts.
- Centralized rack service tag validation and tightened it with stronger format/filler checks while keeping user-facing errors generic.
- Seeded the new pending-L11 rule default in init data.

**Frontend**

- Added admin UI for enabling/disabling the Pending L11 wait rule and setting its required wait time.
- Added full Pending MRB workflow support on SystemPage, including destination availability, confirmations, blocking rules, and defective-part tracking UI.
- Updated pending-material label printing so Pending MRB uses MRB-specific wording in both the printable label and the print modal.
- Added print dates to all printable system labels.
- Improved movement gating/tooltips for RMA, Pending L11, and Pending MRB flows based on part state and evidence requirements.
- Added/adjusted confirmation modals for part-status actions and fixed newline rendering in confirm dialogs.
- Added scroll-capped lists for pending/defective/replacement part sections after 5 items, with stable scrollbar behavior.
- Fixed dropdown stacking for defective-part selection so menus render above surrounding form sections.
- Updated root-cause and parts-page behavior tied to unit/part state.
- Updated flowchart arrow rendering behavior in Flowchart.jsx.